### PR TITLE
Bug fix: preserve original text when updating segments

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -474,8 +474,9 @@ class TranslationBackend:
         else:
             updated = new_text
 
+        # Preserve the source text in "original" and only update the
+        # translated version.
         seg["translated"] = updated
-        seg["original"] = new_text
         seg_type = seg["type"]
         if seg_type in ["paragraph", "table_cell"]:
             if "object" in seg:


### PR DESCRIPTION
## Summary
- fix `update_segment` so it doesn't overwrite the original text
- shorten comments per review feedback

## Testing
- `python -m py_compile TranslationBackend.py TranslationUI.py translation-fun.py`

------
https://chatgpt.com/codex/tasks/task_e_685424844db08331b9833ab21b01455b