### PR TITLE
Fix feedback callback argument semantics and add regression tests

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -575,13 +575,26 @@ class TranslationBackend:
         else:
             raise ValueError(f"Unsupported file extension: {file_extension}")
 
-    def record_feedback(self, approved: bool, original: str, translated: str):
+    def record_feedback(self, *, approved: bool, original: str, translated: str) -> bool:
         """
         Append a JSONL record for approved segments,
         using the language the user originally picked.
         """
+        if not isinstance(approved, bool):
+            raise TypeError("approved must be a bool.")
+        if not isinstance(original, str):
+            raise TypeError("original must be a string.")
+        if not isinstance(translated, str):
+            raise TypeError("translated must be a string.")
+
+        original = original.strip()
+        translated = translated.strip()
+
+        if approved and (not original or not translated):
+            raise ValueError("original and translated must be non-empty when approved is True.")
+
         if not approved:
-            return
+            return False
 
         # Grab the language the user requested at the start of translate_file
         lang = getattr(self, "current_target_language", "unknown")
@@ -598,3 +611,4 @@ class TranslationBackend:
 
         with open(path, "a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return True

--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -589,7 +589,11 @@ class TranslationUI:
         try:
             orig = self.original_segments_map.get(seg_id, "")
             trans = self.translated_segments_map.get(seg_id, "")
-            self.backend.record_feedback(original=orig, translated=trans)
+            self.backend.record_feedback(
+                approved=True,
+                original=orig,
+                translated=trans,
+            )
             ui.notify("Segment approved ✓", type="positive")
         except Exception as ex:
             logging.error(f"[UI] Error approving segment {seg_id}: {ex}", exc_info=True)
@@ -599,7 +603,11 @@ class TranslationUI:
         try:
             orig = self.original_segments_map.get(seg_id, "")
             trans = self.translated_segments_map.get(seg_id, "")
-            self.backend.record_feedback(seg_id, approved=False, original=orig, translated=trans)
+            self.backend.record_feedback(
+                approved=False,
+                original=orig,
+                translated=trans,
+            )
             ui.notify("Segment declined ✗", type="warning")
         except Exception as ex:
             logging.error(f"[UI] Error declining segment {seg_id}: {ex}", exc_info=True)

--- a/tests/test_feedback_callbacks.py
+++ b/tests/test_feedback_callbacks.py
@@ -1,0 +1,58 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from TranslationBackend import TranslationBackend
+from TranslationUI import TranslationUI
+
+
+def _mute_ui_notifications(monkeypatch):
+    monkeypatch.setattr("TranslationUI.ui.notify", lambda *args, **kwargs: None)
+
+
+def test_approve_decline_callbacks_do_not_raise_typeerror(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("FEEDBACK_DIR", str(tmp_path))
+    _mute_ui_notifications(monkeypatch)
+
+    ui_app = TranslationUI()
+    ui_app.original_segments_map = {"seg-1": "Hello"}
+    ui_app.translated_segments_map = {"seg-1": "Hola"}
+
+    ui_app.approve_segment_callback("seg-1")
+    ui_app.decline_segment_callback("seg-1")
+
+    feedback_file = tmp_path / "trl_finetune_data.jsonl"
+    assert feedback_file.exists()
+
+    rows = feedback_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(rows) == 1
+
+    record = json.loads(rows[0])
+    assert "Translate to" in record["prompt"]
+    assert record["completion"].strip() == "Hola"
+
+
+def test_record_feedback_requires_keywords(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+
+    with pytest.raises(TypeError):
+        backend.record_feedback(True, "Hello", "Hola")
+
+
+def test_record_feedback_validation(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+
+    with pytest.raises(TypeError):
+        backend.record_feedback(approved="yes", original="Hello", translated="Hola")
+
+    with pytest.raises(ValueError):
+        backend.record_feedback(approved=True, original="   ", translated="Hola")


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` regressions when UI callbacks call the backend by making `record_feedback` keyword-only and ensuring UI passes the correct keywords and semantics.
- Make `TranslationBackend.record_feedback` defensive about argument types and required content for approved feedback so invalid usage fails early and predictably.
- Add regression tests to cover approve/decline flows and the new validation rules so future changes don't reintroduce the issue.

### Description
- Updated `TranslationUI.approve_segment_callback` to call `self.backend.record_feedback(approved=True, original=orig, translated=trans)` so approval is explicit and uses keywords.
- Updated `TranslationUI.decline_segment_callback` to call `self.backend.record_feedback(approved=False, original=orig, translated=trans)` and removed the positional `seg_id` argument usage.
- Changed `TranslationBackend.record_feedback` signature to `def record_feedback(self, *, approved: bool, original: str, translated: str) -> bool` and added type checks, whitespace trimming, and a non-empty-content check when `approved` is `True`, returning a boolean to indicate whether a record was written.
- Added `tests/test_feedback_callbacks.py` with tests that mute UI notifications, exercise the approve/decline callbacks (asserting no `TypeError` and that a feedback record is written), and assert keyword-only enforcement and validation errors in `record_feedback`.

### Testing
- Ran `pytest -q` in the repository root and all tests passed with the new suite; output: `5 passed in 2.59s`.
- The new tests include: `test_approve_decline_callbacks_do_not_raise_typeerror`, `test_record_feedback_requires_keywords`, and `test_record_feedback_validation`, and they succeeded under CI-local `pytest` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c347f72083319ca9859a40f503a5)