### PR TITLE
Add normalized translation cache keys and OpenAI retry handling

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -4,6 +4,7 @@ import string
 import time
 import uuid
 import json
+import random
 from html import escape
 from io import BytesIO
 from typing import Tuple
@@ -42,6 +43,10 @@ class TranslationBackend:
         self.current_pdf = None
         self.output_stream: BytesIO | None = None
         self.pdf_overlay_ocg = None
+        self.translation_cache: dict[tuple[str, str, str], str] = {}
+        self.max_openai_attempts = 4
+        self.retry_base_delay = 0.5
+        self.retry_max_delay = 8.0
 
     def reset_cancel(self) -> None:
         self.cancel_requested = False
@@ -53,12 +58,64 @@ class TranslationBackend:
     def generate_segment_id(self) -> str:
         return str(uuid.uuid4())
 
+    def _normalize_cache_key(self, text: str, target_language: str, mode: str) -> tuple[str, str, str]:
+        normalized_text = " ".join(text.replace("\t", " ").split())
+        normalized_target = " ".join(target_language.lower().split())
+        normalized_mode = " ".join(mode.lower().split())
+        return normalized_text, normalized_target, normalized_mode
+
+    def _is_transient_openai_error(self, error: Exception) -> bool:
+        transient_types = tuple(
+            err
+            for err in (
+                getattr(openai, "APIConnectionError", None),
+                getattr(openai, "APITimeoutError", None),
+                getattr(openai, "RateLimitError", None),
+                getattr(openai, "InternalServerError", None),
+            )
+            if err is not None
+        )
+
+        if transient_types and isinstance(error, transient_types):
+            return True
+
+        status_code = getattr(error, "status_code", None)
+        return status_code in {408, 409, 429, 500, 502, 503, 504}
+
+    def _create_chat_completion_with_retry(self, messages):
+        attempts = self.max_openai_attempts
+        for attempt in range(1, attempts + 1):
+            try:
+                return self.client.chat.completions.create(model="gpt-4.1-nano", messages=messages, max_tokens=4000)
+            except Exception as error:
+                is_transient = self._is_transient_openai_error(error)
+                if attempt >= attempts or not is_transient:
+                    raise
+
+                delay = min(self.retry_base_delay * (2 ** (attempt - 1)), self.retry_max_delay)
+                jitter = random.uniform(0, delay * 0.25)
+                sleep_seconds = delay + jitter
+                logging.warning(
+                    "[Backend] transient OpenAI error (%s) on attempt %d/%d, retrying in %.2fs",
+                    type(error).__name__,
+                    attempt,
+                    attempts,
+                    sleep_seconds,
+                )
+                time.sleep(sleep_seconds)
+
     # ───────────────────────────── GPT CORE ────────────────────────────── #
     def translate_text(self, text: str, target_language: str) -> str:
         """Translate free-form text via GPT."""
         text = text.replace("\t", " ").strip()
         if not text:
             return text
+
+        cache_key = self._normalize_cache_key(text, target_language, mode="translate")
+        cached = self.translation_cache.get(cache_key)
+        if cached is not None:
+            logging.info("[Backend] translate_text cache hit for target=%s", target_language)
+            return cached
 
         prompt = (
             f"Translate the following text to {target_language}, preserving meaning and context. "
@@ -71,8 +128,9 @@ class TranslationBackend:
             {"role": "user", "content": prompt},
         ]
         try:
-            completion = self.client.chat.completions.create(model="gpt-4.1-nano", messages=messages, max_tokens=4000)
+            completion = self._create_chat_completion_with_retry(messages)
             result = completion.choices[0].message.content.strip() or text
+            self.translation_cache[cache_key] = result
             logging.info("[Backend] Translated len=%d → len=%d", len(text), len(result))
             return result
         except Exception as e:
@@ -87,6 +145,14 @@ class TranslationBackend:
         if not original_text:
             return original_text
 
+        normalized_instructions = " ".join(instructions.replace("\t", " ").strip().split())
+        mode = f"instructions:{normalized_instructions}" if normalized_instructions else "instructions"
+        cache_key = self._normalize_cache_key(original_text, target_language, mode=mode)
+        cached = self.translation_cache.get(cache_key)
+        if cached is not None:
+            logging.info("[Backend] instruction translation cache hit for target=%s", target_language)
+            return cached
+
         prompt = (
             "Please refine the following translation according to these instructions. "
             "Ensure that any requested changes—including changing the language—are applied.\n\n"
@@ -99,8 +165,9 @@ class TranslationBackend:
             {"role": "user", "content": prompt},
         ]
         try:
-            completion = self.client.chat.completions.create(model="gpt-4.1-nano", messages=messages, max_tokens=4000)
+            completion = self._create_chat_completion_with_retry(messages)
             result = completion.choices[0].message.content.strip() or original_text
+            self.translation_cache[cache_key] = result
             logging.info("[Backend] Refined translation len=%d", len(result))
             return result
         except Exception as e:

--- a/tests/test_translation_caching_and_retry.py
+++ b/tests/test_translation_caching_and_retry.py
@@ -1,0 +1,104 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from TranslationBackend import TranslationBackend
+
+
+class _StubChatCreate:
+    def __init__(self, responses=None, errors=None):
+        self.calls = 0
+        self._responses = list(responses or [])
+        self._errors = list(errors or [])
+
+    def __call__(self, **_kwargs):
+        self.calls += 1
+        if self._errors:
+            err = self._errors.pop(0)
+            if err is not None:
+                raise err
+        content = self._responses.pop(0) if self._responses else ""
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+        )
+
+
+def _build_backend(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    return TranslationBackend()
+
+
+def test_translate_text_cache_hit_uses_normalized_key(monkeypatch):
+    backend = _build_backend(monkeypatch)
+    stub = _StubChatCreate(responses=["Hola mundo"])
+    monkeypatch.setattr(backend.client.chat.completions, "create", stub)
+
+    first = backend.translate_text("\t Hello   world  ", " Spanish ")
+    second = backend.translate_text("Hello world", "spanish")
+
+    assert first == "Hola mundo"
+    assert second == "Hola mundo"
+    assert stub.calls == 1
+
+
+def test_instruction_translation_cache_hit_uses_mode_and_instructions(monkeypatch):
+    backend = _build_backend(monkeypatch)
+    stub = _StubChatCreate(responses=["Veuillez reformuler"])
+    monkeypatch.setattr(backend.client.chat.completions, "create", stub)
+
+    first = backend.translate_text_with_instructions(
+        "  Please rephrase this ", "French", " Use formal tone "
+    )
+    second = backend.translate_text_with_instructions(
+        "Please rephrase this", " french ", "use   formal tone"
+    )
+
+    assert first == "Veuillez reformuler"
+    assert second == "Veuillez reformuler"
+    assert stub.calls == 1
+
+
+def test_translate_text_retries_on_transient_openai_error(monkeypatch):
+    backend = _build_backend(monkeypatch)
+    backend.retry_base_delay = 0.01
+    backend.retry_max_delay = 0.02
+
+    transient = Exception("temporary outage")
+    transient.status_code = 503
+    stub = _StubChatCreate(errors=[transient, None], responses=["Recovered translation"])
+    monkeypatch.setattr(backend.client.chat.completions, "create", stub)
+
+    slept = []
+    monkeypatch.setattr("TranslationBackend.time.sleep", lambda seconds: slept.append(seconds))
+
+    translated = backend.translate_text("Resilient text", "German")
+
+    assert translated == "Recovered translation"
+    assert stub.calls == 2
+    assert len(slept) == 1
+    assert slept[0] >= backend.retry_base_delay
+
+
+def test_translate_text_stops_after_max_attempts(monkeypatch):
+    backend = _build_backend(monkeypatch)
+    backend.max_openai_attempts = 3
+    backend.retry_base_delay = 0
+    backend.retry_max_delay = 0
+
+    transient = Exception("still failing")
+    transient.status_code = 503
+    stub = _StubChatCreate(errors=[transient, transient, transient])
+    monkeypatch.setattr(backend.client.chat.completions, "create", stub)
+    monkeypatch.setattr("TranslationBackend.time.sleep", lambda _seconds: None)
+
+    original = "Fallback text"
+    translated = backend.translate_text(original, "Italian")
+
+    assert translated == original
+    assert stub.calls == backend.max_openai_attempts


### PR DESCRIPTION
### Motivation
- Avoid duplicate OpenAI calls by caching translation results keyed on normalized source text, target language, and mode.
- Ensure instruction-based refinements are cached separately and deterministically by including normalized instructions in the cache key.
- Improve robustness against transient OpenAI errors by adding an exponential-backoff retry policy with jitter and a max-attempt limit.

### Description
- Added an in-memory `translation_cache` and normalization helper `
_normalize_cache_key(text, target_language, mode)` to derive stable `(text, language, mode)` keys.
- Implemented transient-error detection in `_is_transient_openai_error` and a retry wrapper `_create_chat_completion_with_retry` that performs exponential backoff with jitter and respects `max_openai_attempts`, `retry_base_delay`, and `retry_max_delay`.
- Updated `translate_text` to check the normalized cache (mode `"translate"`), call OpenAI through the retry helper, and store successful responses in the cache.
- Updated `translate_text_with_instructions` to normalize instructions into the mode (e.g., `instructions:<normalized>`) and to use the same cache + retry flow.
- Added tests `tests/test_translation_caching_and_retry.py` which stub the chat `create` call to validate cache-hit semantics and retry behavior (transient failure then success and max-attempt exhaustion).

### Testing
- Ran `pytest -q tests/test_translation_caching_and_retry.py tests/test_pdf_segment_edit.py` and all tests passed (6 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c34c40188331aa6de1eab0977f26)