### PR TITLE
Add correlation-aware structured logs and reusable translation metrics

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -6,8 +6,7 @@ import uuid
 import json
 from html import escape
 from io import BytesIO
-from typing import Tuple
-from typing import Optional
+from typing import Any, Optional, Tuple
 
 import dotenv
 import fitz  # PyMuPDF
@@ -18,10 +17,21 @@ from pptx import Presentation
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.util import Pt
 
+from translation_metrics import MetricsCollector, TranslationMetrics
+
 dotenv.load_dotenv()
 logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger("translation.backend")
 
 WHITE = (1, 1, 1)  # RGB white for PDF overwrite
+MODEL_COST_PER_1K_TOKENS = 0.002
+
+
+def _log_event(event: str, correlation_id: str | None = None, **fields: Any) -> None:
+    payload: dict[str, Any] = {"event": event, **fields}
+    if correlation_id:
+        payload["correlation_id"] = correlation_id
+    LOGGER.info(json.dumps(payload, default=str))
 
 
 class TranslationBackend:
@@ -42,6 +52,8 @@ class TranslationBackend:
         self.current_pdf = None
         self.output_stream: BytesIO | None = None
         self.pdf_overlay_ocg = None
+        self.translation_cache: dict[tuple[str, str], str] = {}
+        self.metrics: TranslationMetrics = MetricsCollector()
 
     def reset_cancel(self) -> None:
         self.cancel_requested = False
@@ -54,11 +66,30 @@ class TranslationBackend:
         return str(uuid.uuid4())
 
     # ───────────────────────────── GPT CORE ────────────────────────────── #
-    def translate_text(self, text: str, target_language: str) -> str:
+    def translate_text(
+        self,
+        text: str,
+        target_language: str,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
+    ) -> str:
         """Translate free-form text via GPT."""
         text = text.replace("\t", " ").strip()
         if not text:
             return text
+        metrics = file_metrics or self.metrics
+        cache_key = (target_language, text)
+        if cache_key in self.translation_cache:
+            cached = self.translation_cache[cache_key]
+            metrics.record_cache_hit()
+            _log_event(
+                "translation.cache_hit",
+                correlation_id=correlation_id,
+                source_length=len(text),
+                translated_length=len(cached),
+            )
+            return cached
+        metrics.record_cache_miss()
 
         prompt = (
             f"Translate the following text to {target_language}, preserving meaning and context. "
@@ -70,14 +101,46 @@ class TranslationBackend:
             {"role": "system", "content": f"You are a helpful assistant translating to {target_language}."},
             {"role": "user", "content": prompt},
         ]
-        try:
-            completion = self.client.chat.completions.create(model="gpt-4.1-nano", messages=messages, max_tokens=4000)
-            result = completion.choices[0].message.content.strip() or text
-            logging.info("[Backend] Translated len=%d → len=%d", len(text), len(result))
-            return result
-        except Exception as e:
-            logging.error("[Backend] translate_text error: %s", e, exc_info=True)
-            return text
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            try:
+                completion = self.client.chat.completions.create(model="gpt-4.1-nano", messages=messages, max_tokens=4000)
+                result = completion.choices[0].message.content.strip() or text
+                self.translation_cache[cache_key] = result
+                token_total = self.calculate_tokens(text + "\n" + result)
+                metrics.record_segment(
+                    duration_seconds=0.0,
+                    token_count=token_total,
+                    estimated_cost=(token_total * MODEL_COST_PER_1K_TOKENS) / 1000,
+                )
+                _log_event(
+                    "translation.segment_done",
+                    correlation_id=correlation_id,
+                    source_length=len(text),
+                    translated_length=len(result),
+                    tokens=token_total,
+                    retry_count=attempt - 1,
+                )
+                return result
+            except Exception as e:
+                if attempt < max_attempts:
+                    metrics.record_retry()
+                    _log_event(
+                        "translation.segment_retry",
+                        correlation_id=correlation_id,
+                        attempt=attempt,
+                        error=str(e),
+                    )
+                    time.sleep(0.3 * attempt)
+                    continue
+                logging.error("[Backend] translate_text error: %s", e, exc_info=True)
+                _log_event(
+                    "translation.segment_failed",
+                    correlation_id=correlation_id,
+                    error=str(e),
+                    attempts=max_attempts,
+                )
+                return text
 
     def translate_text_with_instructions(
         self, original_text: str, target_language: str, instructions: str
@@ -224,8 +287,19 @@ class TranslationBackend:
     # ------------------
     # PROCESSING DOCX
     # ------------------
-    def process_docx(self, input_stream, target_language, progress_ui, label_ui, do_translate=True):
+    def process_docx(
+        self,
+        input_stream,
+        target_language,
+        progress_ui,
+        label_ui,
+        do_translate=True,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
+    ):
         self.reset_cancel()
+        metrics = file_metrics or self.metrics
+        metrics.start_file(file_type="docx", correlation_id=correlation_id)
         doc = Document(input_stream)
         self.current_file_type = 'docx'
         self.current_document = doc
@@ -243,7 +317,11 @@ class TranslationBackend:
                 continue
             if self.cancel_requested:
                 break
-            new_text = self.translate_text(original, target_language) if do_translate else original
+            seg_start = time.time()
+            new_text = (
+                self.translate_text(original, target_language, correlation_id=correlation_id, file_metrics=metrics)
+                if do_translate else original
+            )
             para.text = new_text
             text_accum += new_text + "\n"
             seg_id = self.generate_segment_id()
@@ -256,6 +334,7 @@ class TranslationBackend:
                 "object": para
             }
             processed += 1
+            metrics.add_segment_duration(time.time() - seg_start)
             self.update_progress(processed, total_elements, start_time, progress_ui, label_ui)
 
         # Table cells
@@ -268,7 +347,16 @@ class TranslationBackend:
                             continue
                         if self.cancel_requested:
                             break
-                        new_text = self.translate_text(original, target_language) if do_translate else original
+                        seg_start = time.time()
+                        new_text = (
+                            self.translate_text(
+                                original,
+                                target_language,
+                                correlation_id=correlation_id,
+                                file_metrics=metrics,
+                            )
+                            if do_translate else original
+                        )
                         para.text = new_text
                         text_accum += new_text + "\n"
                         seg_id = self.generate_segment_id()
@@ -281,6 +369,7 @@ class TranslationBackend:
                             "object": para
                         }
                         processed += 1
+                        metrics.add_segment_duration(time.time() - seg_start)
                         self.update_progress(processed, total_elements, start_time, progress_ui, label_ui)
 
         out_stream = BytesIO()
@@ -288,6 +377,11 @@ class TranslationBackend:
         out_stream.seek(0)
         self.output_stream = out_stream
         tokens = self.calculate_tokens(text_accum)
+        metrics.finish_file(
+            file_type="docx",
+            segment_count=processed,
+            duration_seconds=time.time() - start_time,
+        )
         return out_stream, processed, tokens, text_accum, self.segment_map
 
     # ------------------
@@ -301,10 +395,13 @@ class TranslationBackend:
         label_ui,
         do_translate=True,
         font_size=None,
-        autofit=False
+        autofit=False,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
     ):
-    
+        metrics = file_metrics or self.metrics
         self.reset_cancel()
+        metrics.start_file(file_type="pptx", correlation_id=correlation_id)
         prs = Presentation(input_stream)
         self.current_file_type = 'pptx'
         self.current_presentation = prs
@@ -322,7 +419,9 @@ class TranslationBackend:
                     continue
 
                 if do_translate:
-                    new_text = self._translate_shape(shape, target_language, font_size, autofit)
+                    seg_start = time.time()
+                    new_text = self._translate_shape(shape, target_language, font_size, autofit, correlation_id, metrics)
+                    metrics.add_segment_duration(time.time() - seg_start)
                 else:
                     new_text = original_text
 
@@ -347,9 +446,22 @@ class TranslationBackend:
         out_stream.seek(0)
         self.output_stream = out_stream
         tokens = self.calculate_tokens(text_accum)
+        metrics.finish_file(
+            file_type="pptx",
+            segment_count=processed,
+            duration_seconds=time.time() - start_time,
+        )
         return out_stream, processed, tokens, text_accum, self.segment_map
 
-    def _translate_shape(self, shape, target_language, font_size=None, autofit=False):
+    def _translate_shape(
+        self,
+        shape,
+        target_language,
+        font_size=None,
+        autofit=False,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
+    ):
         def apply_formatting(tf):
             # 1) Set every paragraph & run to the user’s max size
             if font_size:
@@ -371,19 +483,36 @@ class TranslationBackend:
                     tf = cell.text_frame
                     if not tf: continue
                     text = tf.text.strip()
-                    new_text = self.translate_text(text, target_language)
+                    new_text = self.translate_text(
+                        text,
+                        target_language,
+                        correlation_id=correlation_id,
+                        file_metrics=file_metrics,
+                    )
                     tf.text = new_text
                     apply_formatting(tf)
                     result += new_text + "\n"
 
         elif shape.shape_type == MSO_SHAPE_TYPE.GROUP:
             for sub in shape.shapes:
-                result += self._translate_shape(sub, target_language, font_size, autofit) + "\n"
+                result += self._translate_shape(
+                    sub,
+                    target_language,
+                    font_size,
+                    autofit,
+                    correlation_id=correlation_id,
+                    file_metrics=file_metrics,
+                ) + "\n"
 
         elif hasattr(shape, "text_frame") and shape.text_frame:
             tf = shape.text_frame
             original = tf.text.strip()
-            new_text = self.translate_text(original, target_language)
+            new_text = self.translate_text(
+                original,
+                target_language,
+                correlation_id=correlation_id,
+                file_metrics=file_metrics,
+            )
             tf.text = new_text
             apply_formatting(tf)
             result += new_text + "\n"
@@ -416,7 +545,18 @@ class TranslationBackend:
     # ------------------
     # PROCESSING PDF
     # ------------------
-    def process_pdf(self, input_stream, target_language, progress_ui, label_ui, do_translate=True):
+    def process_pdf(
+        self,
+        input_stream,
+        target_language,
+        progress_ui,
+        label_ui,
+        do_translate=True,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
+    ):
+        metrics = file_metrics or self.metrics
+        metrics.start_file(file_type="pdf", correlation_id=correlation_id)
         logging.info("[PDF] Opening document for translation")
         doc = fitz.open(stream=input_stream, filetype="pdf")
         self.current_file_type = 'pdf'
@@ -473,7 +613,17 @@ class TranslationBackend:
                 }
                 logging.debug(f"[PDF] Registered segment {seg_id[:8]} at {bbox}")
 
-                new_text = original if not do_translate else self.translate_text(original, target_language)
+                seg_start = time.time()
+                new_text = (
+                    original
+                    if not do_translate
+                    else self.translate_text(
+                        original,
+                        target_language,
+                        correlation_id=correlation_id,
+                        file_metrics=metrics,
+                    )
+                )
                 self.segment_map[seg_id]["translated"] = new_text
 
                 last_css = self._render_pdf_block(page, bbox, new_text)
@@ -481,6 +631,7 @@ class TranslationBackend:
                 logging.debug(f"[PDF] Translated segment {seg_id[:8]}")
 
                 processed += 1
+                metrics.add_segment_duration(time.time() - seg_start)
                 self.update_progress(processed, total_blocks, start_time, progress_ui, label_ui)
 
         # 4) Finalize, subset fonts & save
@@ -493,6 +644,11 @@ class TranslationBackend:
 
         tokens = self.calculate_tokens("")  # or track actual text if desired
         logging.info(f"[PDF] Done – {processed}/{total_blocks} blocks processed, tokens={tokens}")
+        metrics.finish_file(
+            file_type="pdf",
+            segment_count=processed,
+            duration_seconds=time.time() - start_time,
+        )
         return out_stream, processed, tokens, "", self.segment_map
 
     # ------------------
@@ -553,27 +709,61 @@ class TranslationBackend:
         label_ui,
         processed=False,
         font_size=None,
-        autofit=False
+        autofit=False,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
     ):
         self.reset_cancel()
         self.current_target_language = target_language
+        metrics = file_metrics or self.metrics
+        _log_event(
+            "translation.file_started",
+            correlation_id=correlation_id,
+            file_extension=file_extension,
+            processed=processed,
+            target_language=target_language,
+        )
         ext = file_extension.lower()
         if ext == "docx":
-            return self.process_docx(input_stream, target_language, progress_ui, label_ui, do_translate=not processed)
+            result = self.process_docx(
+                input_stream,
+                target_language,
+                progress_ui,
+                label_ui,
+                do_translate=not processed,
+                correlation_id=correlation_id,
+                file_metrics=metrics,
+            )
         elif ext == "pptx":
-            return self.process_pptx(
+            result = self.process_pptx(
                 input_stream,
                 target_language,
                 progress_ui,
                 label_ui,
                 do_translate=not processed,
                 font_size=font_size,
-                autofit=autofit
+                autofit=autofit,
+                correlation_id=correlation_id,
+                file_metrics=metrics,
             )
         elif ext == "pdf":
-            return self.process_pdf(input_stream, target_language, progress_ui, label_ui, do_translate=not processed)
+            result = self.process_pdf(
+                input_stream,
+                target_language,
+                progress_ui,
+                label_ui,
+                do_translate=not processed,
+                correlation_id=correlation_id,
+                file_metrics=metrics,
+            )
         else:
             raise ValueError(f"Unsupported file extension: {file_extension}")
+        _log_event(
+            "translation.file_finished",
+            correlation_id=correlation_id,
+            metrics=metrics.snapshot(),
+        )
+        return result
 
     def record_feedback(self, approved: bool, original: str, translated: str):
         """

--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -2,6 +2,9 @@ import asyncio
 import logging
 import os
 import glob
+import json
+import time
+import uuid
 from io import BytesIO
 from threading import Thread
 from typing import Any
@@ -11,8 +14,17 @@ from fastapi import UploadFile, File, Form
 from starlette.responses import Response
 
 from TranslationBackend import TranslationBackend
+from translation_metrics import MetricsCollector
 
 logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger("translation.ui")
+
+
+def _log_event(event: str, correlation_id: str | None = None, **fields: Any) -> None:
+    payload: dict[str, Any] = {"event": event, **fields}
+    if correlation_id:
+        payload["correlation_id"] = correlation_id
+    LOGGER.info(json.dumps(payload, default=str))
 
 
 class TranslationUI:
@@ -31,6 +43,7 @@ class TranslationUI:
         self.uploaded_file_name: str | None = None
         self.uploaded_file_extension: str | None = None
         self.current_target_language: str | None = None
+        self.current_correlation_id: str | None = None
         self.cancel_button = None
 
         # ── SEGMENT EDITING ─────────────────────────────────────────────
@@ -312,6 +325,15 @@ class TranslationUI:
             self.show_error("Please enter a valid target language.")
             return
         self.current_target_language = target_language
+        correlation_id = str(uuid.uuid4())
+        self.current_correlation_id = correlation_id
+        _log_event(
+            "ui.translation_requested",
+            correlation_id=correlation_id,
+            file_name=self.uploaded_file_name,
+            file_extension=self.uploaded_file_extension,
+            target_language=target_language,
+        )
         logging.info(f"[UI] Translating '{self.uploaded_file_name}' → {target_language}")
 
         # clear old UI
@@ -332,6 +354,8 @@ class TranslationUI:
             self.cancel_button
 
         def translation_task():
+            file_metrics = MetricsCollector()
+            started = time.time()
             try:
                 out_stream, count, tokens, _, seg_map = self.backend.translate_file(
                     self.uploaded_file,
@@ -341,10 +365,13 @@ class TranslationUI:
                     label_ui,
                     processed=False,
                     font_size=font_size,
-                    autofit=autofit
+                    autofit=autofit,
+                    correlation_id=correlation_id,
+                    file_metrics=file_metrics,
                 )
                 if self.backend.cancel_requested:
                     logging.info("[UI] Translation canceled mid-way.")
+                    _log_event("ui.translation_cancelled", correlation_id=correlation_id)
                     return
 
                 progress_ui.set_value(100)
@@ -361,9 +388,16 @@ class TranslationUI:
                     self.original_segments_map[seg_id] = seg_info["original"]
                     self.translated_segments_map[seg_id] = seg_info["translated"]
 
+                _log_event(
+                    "ui.translation_complete",
+                    correlation_id=correlation_id,
+                    elapsed_seconds=round(time.time() - started, 3),
+                    metrics=file_metrics.snapshot(),
+                )
                 self.show_result()
             except Exception as e:
                 logging.error(f"[UI] Translation error: {e}", exc_info=True)
+                _log_event("ui.translation_failed", correlation_id=correlation_id, error=str(e))
                 self.show_error(e)
 
         Thread(target=translation_task).start()
@@ -374,6 +408,14 @@ class TranslationUI:
         self.result_container.clear()
         self.stats_container.clear()
 
+        correlation_id = str(uuid.uuid4())
+        self.current_correlation_id = correlation_id
+        _log_event(
+            "ui.processed_file_open_requested",
+            correlation_id=correlation_id,
+            file_name=self.uploaded_file_name,
+            file_extension=self.uploaded_file_extension,
+        )
         progress_ui = ui.circular_progress(value=0, max=100, show_value=True)\
             .classes("mx-auto mt-4").style("color: #ff9800;")
         label_ui = ui.label("Loading processed document...")\
@@ -387,6 +429,7 @@ class TranslationUI:
             self.cancel_button
 
         def processed_task():
+            file_metrics = MetricsCollector()
             try:
                 out_stream, count, _, _, seg_map = self.backend.translate_file(
                     self.uploaded_file,
@@ -394,7 +437,9 @@ class TranslationUI:
                     "",
                     progress_ui,
                     label_ui,
-                    processed=True
+                    processed=True,
+                    correlation_id=correlation_id,
+                    file_metrics=file_metrics,
                 )
                 progress_ui.set_value(100)
                 label_ui.text = "File loaded."
@@ -409,9 +454,15 @@ class TranslationUI:
                     self.original_segments_map[seg_id] = seg_info["original"]
                     self.translated_segments_map[seg_id] = seg_info["translated"]
 
+                _log_event(
+                    "ui.processed_file_open_complete",
+                    correlation_id=correlation_id,
+                    metrics=file_metrics.snapshot(),
+                )
                 self.show_result()
             except Exception as e:
                 logging.error(f"[UI] Error loading processed doc: {e}", exc_info=True)
+                _log_event("ui.processed_file_open_failed", correlation_id=correlation_id, error=str(e))
                 self.show_error(e)
 
         Thread(target=processed_task).start()
@@ -773,10 +824,12 @@ class TranslationUI:
         file: UploadFile = File(...),
         language: str = Form(...)
     ) -> Response:
+        correlation_id = str(uuid.uuid4())
         try:
             if not language or language.lower() in ('undefined','null',''):
                 language = 'es'
                 logging.warning("[API] Empty language → default to Spanish")
+            _log_event("ui.voice_translate_requested", correlation_id=correlation_id, language=language)
             data = await file.read()
             if not data:
                 return Response(content=b"", status_code=400, headers={"X-Error":"Empty audio data"})
@@ -806,11 +859,13 @@ class TranslationUI:
                     "X-Original-Text": header_orig,
                     "X-Translated-Text": translation_text,
                     "X-Target-Language": language,
+                    "X-Correlation-Id": correlation_id,
                     "Content-Length": str(len(mp3_bytes))
                 }
             )
         except Exception as e:
             logging.error(f"[API] Voice error: {e}", exc_info=True)
+            _log_event("ui.voice_translate_failed", correlation_id=correlation_id, error=str(e))
             msg = f"Translation error: {e}"
             return Response(content=msg.encode(), status_code=500,
                             media_type="text/plain", headers={"X-Error":msg})

--- a/translation_metrics.py
+++ b/translation_metrics.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class TranslationMetrics(Protocol):
+    """Lightweight instrumentation contract reusable by async/job workers."""
+
+    def start_file(self, file_type: str, correlation_id: str | None = None) -> None: ...
+
+    def record_segment(self, duration_seconds: float, token_count: int, estimated_cost: float) -> None: ...
+
+    def add_segment_duration(self, duration_seconds: float) -> None: ...
+
+    def record_cache_hit(self) -> None: ...
+
+    def record_cache_miss(self) -> None: ...
+
+    def record_retry(self) -> None: ...
+
+    def finish_file(self, file_type: str, segment_count: int, duration_seconds: float) -> None: ...
+
+    def snapshot(self) -> dict: ...
+
+
+@dataclass
+class MetricsCollector:
+    correlation_id: str | None = None
+    file_type: str | None = None
+    duration_seconds: float = 0.0
+    segment_count: int = 0
+    segment_duration_seconds: float = 0.0
+    token_count: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    retries: int = 0
+    estimated_cost: float = 0.0
+
+    def start_file(self, file_type: str, correlation_id: str | None = None) -> None:
+        self.correlation_id = correlation_id
+        self.file_type = file_type
+        self.duration_seconds = 0.0
+        self.segment_count = 0
+        self.segment_duration_seconds = 0.0
+        self.token_count = 0
+        self.cache_hits = 0
+        self.cache_misses = 0
+        self.retries = 0
+        self.estimated_cost = 0.0
+
+    def record_segment(self, duration_seconds: float, token_count: int, estimated_cost: float) -> None:
+        self.segment_count += 1
+        self.segment_duration_seconds += max(0.0, duration_seconds)
+        self.token_count += max(0, token_count)
+        self.estimated_cost += max(0.0, estimated_cost)
+
+    def add_segment_duration(self, duration_seconds: float) -> None:
+        self.segment_duration_seconds += max(0.0, duration_seconds)
+
+    def record_cache_hit(self) -> None:
+        self.cache_hits += 1
+
+    def record_cache_miss(self) -> None:
+        self.cache_misses += 1
+
+    def record_retry(self) -> None:
+        self.retries += 1
+
+    def finish_file(self, file_type: str, segment_count: int, duration_seconds: float) -> None:
+        self.file_type = file_type
+        self.segment_count = max(self.segment_count, segment_count)
+        self.duration_seconds = max(0.0, duration_seconds)
+
+    def snapshot(self) -> dict:
+        return {
+            "correlation_id": self.correlation_id,
+            "file_type": self.file_type,
+            "duration_seconds": round(self.duration_seconds, 3),
+            "segment_count": self.segment_count,
+            "segment_duration_seconds": round(self.segment_duration_seconds, 3),
+            "token_count": self.token_count,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "retries": self.retries,
+            "estimated_cost": round(self.estimated_cost, 6),
+        }


### PR DESCRIPTION
### Motivation
- Provide end-to-end observability for translations by attaching correlation identifiers to UI/API flows and backend processing events.
- Capture per-file and per-segment metrics (durations, token counts, cache hits/misses, retries, estimated cost) so future job-queue or worker code can reuse the same instrumentation.
- Keep the logging payloads structured (JSON) to make them easy to index in log systems.

### Description
- Added a lightweight instrumentation contract in `translation_metrics.py` (`TranslationMetrics` protocol) and an in-memory implementation `MetricsCollector` that tracks per-file duration, segment counts/duration, token totals, cache hits/misses, retries, and estimated cost snapshots.
- Introduced structured JSON logging helpers (`_log_event`) and a `LOGGER` in `TranslationBackend.py` and `TranslationUI.py`, and wired correlation IDs through UI flows and backend calls to produce `translation.file_started`, `translation.segment_done`, `translation.segment_retry`, `translation.segment_failed`, and `translation.file_finished` events along with metric snapshots.
- Instrumented `translate_text` with a small translation cache, cache hit/miss metrics, retry handling (up to 3 attempts), token counting and per-segment `record_segment` calls to accumulate estimated cost and token totals.
- Wired metrics into file processors (`process_docx`, `process_pptx`, `process_pdf`) to `start_file`/`finish_file`, track per-segment durations via `add_segment_duration`, and propagate the `file_metrics` and `correlation_id` from `TranslationUI` into `TranslationBackend` calls; added `X-Correlation-Id` header on the voice API response.

### Testing
- Verified Python syntax compilation with `python -m py_compile TranslationBackend.py TranslationUI.py translation_metrics.py` (success).
- Ran test suite with `pytest -q` and received `2 passed` (all tests successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c35944148331ae42f52e2b06567e)