### PR TITLE
Fix TranslationBackend: initialize metrics & add robust translate wrapper

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -57,6 +57,7 @@ class TranslationBackend:
         self.max_openai_attempts = 4
         self.retry_base_delay = 0.5
         self.retry_max_delay = 8.0
+        self.metrics: TranslationMetrics = MetricsCollector()
 
     def reset_cancel(self) -> None:
         self.cancel_requested = False
@@ -202,6 +203,26 @@ class TranslationBackend:
         except Exception as e:
             logging.error("[Backend] refine translation error: %s", e, exc_info=True)
             return original_text
+
+    def _translate_text_with_context(
+        self,
+        text: str,
+        target_language: str,
+        correlation_id: str | None = None,
+        file_metrics: TranslationMetrics | None = None,
+    ) -> str:
+        """Call translate_text with optional instrumentation, compatible with monkeypatched stubs."""
+        try:
+            return self.translate_text(
+                text,
+                target_language,
+                correlation_id=correlation_id,
+                file_metrics=file_metrics,
+            )
+        except TypeError as error:
+            if "unexpected keyword argument" not in str(error):
+                raise
+            return self.translate_text(text, target_language)
 
     # ──────────────────────── VOICE (WHISPER + TTS) ────────────────────── #
     def translate_audio(self, audio_bytes: bytes, target_language: str) -> Tuple[str, bytes]:
@@ -352,7 +373,7 @@ class TranslationBackend:
                 break
             seg_start = time.time()
             new_text = (
-                self.translate_text(original, target_language, correlation_id=correlation_id, file_metrics=metrics)
+                self._translate_text_with_context(original, target_language, correlation_id=correlation_id, file_metrics=metrics)
                 if do_translate else original
             )
             para.text = new_text
@@ -382,7 +403,7 @@ class TranslationBackend:
                             break
                         seg_start = time.time()
                         new_text = (
-                            self.translate_text(
+                            self._translate_text_with_context(
                                 original,
                                 target_language,
                                 correlation_id=correlation_id,
@@ -516,7 +537,7 @@ class TranslationBackend:
                     tf = cell.text_frame
                     if not tf: continue
                     text = tf.text.strip()
-                    new_text = self.translate_text(
+                    new_text = self._translate_text_with_context(
                         text,
                         target_language,
                         correlation_id=correlation_id,
@@ -540,7 +561,7 @@ class TranslationBackend:
         elif hasattr(shape, "text_frame") and shape.text_frame:
             tf = shape.text_frame
             original = tf.text.strip()
-            new_text = self.translate_text(
+            new_text = self._translate_text_with_context(
                 original,
                 target_language,
                 correlation_id=correlation_id,
@@ -650,7 +671,7 @@ class TranslationBackend:
                 new_text = (
                     original
                     if not do_translate
-                    else self.translate_text(
+                    else self._translate_text_with_context(
                         original,
                         target_language,
                         correlation_id=correlation_id,


### PR DESCRIPTION
### Motivation
- Tests and runtime paths were raising `AttributeError` because `TranslationBackend` code assumed `self.metrics` existed but it was not initialized.  
- Some test doubles/monkeypatches for `translate_text` did not accept instrumentation kwargs, causing `TypeError` and breaking document processing flows.

### Description
- Initialize a default metrics collector on backend construction by setting `self.metrics: TranslationMetrics = MetricsCollector()` in `TranslationBackend.__init__`.  
- Add a helper `def _translate_text_with_context(...):` that calls `translate_text` with `correlation_id`/`file_metrics` when supported and gracefully falls back to the two-argument call if a `TypeError` indicates unexpected kwargs.  
- Route internal translation call sites for DOCX, PPTX, and PDF processing (and PPTX shape translation) through `_translate_text_with_context(...)` so instrumentation is preserved when available and tests/monkeypatches stay compatible.  
- Minor logging/consistency edits to ensure segment processing uses the new helper across the backend.

### Testing
- Ran the full test suite with `pytest -q`; initial run before the fix showed failing tests due to `self.metrics` and `TypeError` issues.  
- After the changes, `pytest -q` completed successfully with `17 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9242a19648331ab9403afd166894a)