### PR TITLE
Add translation job model and decouple UI from long-running translation path

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -5,9 +5,11 @@ import time
 import uuid
 import json
 import random
+from dataclasses import dataclass, field
+from threading import Lock, Thread
 from html import escape
 from io import BytesIO
-from typing import Any, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import dotenv
 import fitz  # PyMuPDF
@@ -26,6 +28,26 @@ LOGGER = logging.getLogger("translation.backend")
 
 WHITE = (1, 1, 1)  # RGB white for PDF overwrite
 MODEL_COST_PER_1K_TOKENS = 0.002
+
+
+JOB_STATE_QUEUED = "queued"
+JOB_STATE_RUNNING = "running"
+JOB_STATE_SUCCEEDED = "succeeded"
+JOB_STATE_FAILED = "failed"
+JOB_STATE_CANCELED = "canceled"
+
+
+@dataclass
+class TranslationJob:
+    job_id: str
+    state: str = JOB_STATE_QUEUED
+    progress: float = 0.0
+    status_message: str = "Queued"
+    result_handle: str | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
 
 
 def _log_event(event: str, correlation_id: str | None = None, **fields: Any) -> None:
@@ -57,6 +79,10 @@ class TranslationBackend:
         self.max_openai_attempts = 4
         self.retry_base_delay = 0.5
         self.retry_max_delay = 8.0
+        self.metrics = MetricsCollector()
+        self._jobs: dict[str, TranslationJob] = {}
+        self._job_results: dict[str, dict[str, Any]] = {}
+        self._jobs_lock = Lock()
 
     def reset_cancel(self) -> None:
         self.cancel_requested = False
@@ -64,6 +90,158 @@ class TranslationBackend:
     def request_cancel(self) -> None:
         self.cancel_requested = True
         logging.info("[Backend] Cancel requested.")
+
+    def start_translation_job(
+        self,
+        *,
+        input_stream: BytesIO,
+        file_extension: str,
+        target_language: str,
+        processed: bool = False,
+        font_size: int | None = None,
+        autofit: bool = False,
+        correlation_id: str | None = None,
+    ) -> str:
+        job_id = self.generate_segment_id()
+        job = TranslationJob(
+            job_id=job_id,
+            state=JOB_STATE_QUEUED,
+            progress=0.0,
+            status_message="Queued",
+            metadata={
+                "file_extension": file_extension,
+                "target_language": target_language,
+                "processed": processed,
+                "correlation_id": correlation_id,
+            },
+        )
+        with self._jobs_lock:
+            self._jobs[job_id] = job
+
+        def worker():
+            self._run_translation_job(
+                job_id=job_id,
+                input_stream=input_stream,
+                file_extension=file_extension,
+                target_language=target_language,
+                processed=processed,
+                font_size=font_size,
+                autofit=autofit,
+                correlation_id=correlation_id,
+            )
+
+        Thread(target=worker, daemon=True).start()
+        return job_id
+
+    def get_job(self, job_id: str) -> TranslationJob | None:
+        with self._jobs_lock:
+            return self._jobs.get(job_id)
+
+    def get_job_result(self, result_handle: str) -> dict[str, Any] | None:
+        with self._jobs_lock:
+            return self._job_results.get(result_handle)
+
+    def cancel_job(self, job_id: str) -> bool:
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return False
+            if job.state in {JOB_STATE_SUCCEEDED, JOB_STATE_FAILED, JOB_STATE_CANCELED}:
+                return False
+            job.state = JOB_STATE_CANCELED
+            job.status_message = "Cancel requested."
+            job.updated_at = time.time()
+        self.request_cancel()
+        return True
+
+    def _set_job_state(
+        self,
+        job_id: str,
+        *,
+        state: str | None = None,
+        progress: float | None = None,
+        status_message: str | None = None,
+        result_handle: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            if state is not None:
+                job.state = state
+            if progress is not None:
+                job.progress = max(0.0, min(100.0, progress))
+            if status_message is not None:
+                job.status_message = status_message
+            if result_handle is not None:
+                job.result_handle = result_handle
+            if error is not None:
+                job.error = error
+            job.updated_at = time.time()
+
+    def _run_translation_job(
+        self,
+        *,
+        job_id: str,
+        input_stream: BytesIO,
+        file_extension: str,
+        target_language: str,
+        processed: bool,
+        font_size: int | None,
+        autofit: bool,
+        correlation_id: str | None,
+    ) -> None:
+        self._set_job_state(job_id, state=JOB_STATE_RUNNING, status_message="Starting translation...")
+        file_metrics = MetricsCollector()
+        try:
+            out_stream, count, tokens, text_accum, seg_map = self.translate_file(
+                input_stream=input_stream,
+                file_extension=file_extension,
+                target_language=target_language,
+                processed=processed,
+                font_size=font_size,
+                autofit=autofit,
+                correlation_id=correlation_id,
+                file_metrics=file_metrics,
+                progress_callback=lambda progress, message: self._set_job_state(
+                    job_id,
+                    progress=progress,
+                    status_message=message,
+                ),
+            )
+            if self.cancel_requested:
+                self._set_job_state(
+                    job_id,
+                    state=JOB_STATE_CANCELED,
+                    status_message="Translation canceled.",
+                )
+                return
+
+            result_handle = self.generate_segment_id()
+            with self._jobs_lock:
+                self._job_results[result_handle] = {
+                    "output_stream": out_stream,
+                    "count": count,
+                    "tokens": tokens,
+                    "text": text_accum,
+                    "segment_map": seg_map,
+                    "metrics": file_metrics.snapshot(),
+                }
+            self._set_job_state(
+                job_id,
+                state=JOB_STATE_SUCCEEDED,
+                progress=100.0,
+                status_message="Translation complete.",
+                result_handle=result_handle,
+            )
+        except Exception as exc:
+            self._set_job_state(
+                job_id,
+                state=JOB_STATE_FAILED,
+                status_message="Translation failed.",
+                error=str(exc),
+            )
 
     def generate_segment_id(self) -> str:
         return str(uuid.uuid4())
@@ -324,11 +502,12 @@ class TranslationBackend:
         self,
         input_stream,
         target_language,
-        progress_ui,
-        label_ui,
+        progress_ui=None,
+        label_ui=None,
         do_translate=True,
         correlation_id: str | None = None,
         file_metrics: TranslationMetrics | None = None,
+        progress_callback: Callable[[float, str], None] | None = None,
     ):
         self.reset_cancel()
         metrics = file_metrics or self.metrics
@@ -368,7 +547,14 @@ class TranslationBackend:
             }
             processed += 1
             metrics.add_segment_duration(time.time() - seg_start)
-            self.update_progress(processed, total_elements, start_time, progress_ui, label_ui)
+            self.update_progress(
+                processed,
+                total_elements,
+                start_time,
+                progress_ui=progress_ui,
+                label_ui=label_ui,
+                progress_callback=progress_callback,
+            )
 
         # Table cells
         for t_idx, table in enumerate(doc.tables):
@@ -403,7 +589,14 @@ class TranslationBackend:
                         }
                         processed += 1
                         metrics.add_segment_duration(time.time() - seg_start)
-                        self.update_progress(processed, total_elements, start_time, progress_ui, label_ui)
+                        self.update_progress(
+                            processed,
+                            total_elements,
+                            start_time,
+                            progress_ui=progress_ui,
+                            label_ui=label_ui,
+                            progress_callback=progress_callback,
+                        )
 
         out_stream = BytesIO()
         doc.save(out_stream)
@@ -424,13 +617,14 @@ class TranslationBackend:
         self,
         input_stream,
         target_language,
-        progress_ui,
-        label_ui,
+        progress_ui=None,
+        label_ui=None,
         do_translate=True,
         font_size=None,
         autofit=False,
         correlation_id: str | None = None,
         file_metrics: TranslationMetrics | None = None,
+        progress_callback: Callable[[float, str], None] | None = None,
     ):
         metrics = file_metrics or self.metrics
         self.reset_cancel()
@@ -471,7 +665,14 @@ class TranslationBackend:
 
                 text_accum += new_text + "\n"
                 processed += 1
-                self.update_progress(processed, total_elements, start_time, progress_ui, label_ui)
+                self.update_progress(
+                    processed,
+                    total_elements,
+                    start_time,
+                    progress_ui=progress_ui,
+                    label_ui=label_ui,
+                    progress_callback=progress_callback,
+                )
 
         # output stream
         out_stream = BytesIO()
@@ -582,11 +783,12 @@ class TranslationBackend:
         self,
         input_stream,
         target_language,
-        progress_ui,
-        label_ui,
+        progress_ui=None,
+        label_ui=None,
         do_translate=True,
         correlation_id: str | None = None,
         file_metrics: TranslationMetrics | None = None,
+        progress_callback: Callable[[float, str], None] | None = None,
     ):
         metrics = file_metrics or self.metrics
         metrics.start_file(file_type="pdf", correlation_id=correlation_id)
@@ -665,7 +867,14 @@ class TranslationBackend:
 
                 processed += 1
                 metrics.add_segment_duration(time.time() - seg_start)
-                self.update_progress(processed, total_blocks, start_time, progress_ui, label_ui)
+                self.update_progress(
+                    processed,
+                    total_blocks,
+                    start_time,
+                    progress_ui=progress_ui,
+                    label_ui=label_ui,
+                    progress_callback=progress_callback,
+                )
 
         # 4) Finalize, subset fonts & save
         out_stream = BytesIO()
@@ -687,13 +896,26 @@ class TranslationBackend:
     # ------------------
     # PROGRESS
     # ------------------
-    def update_progress(self, current, total, start_time, progress_ui, label_ui):
+    def update_progress(
+        self,
+        current,
+        total,
+        start_time,
+        progress_ui=None,
+        label_ui=None,
+        progress_callback: Callable[[float, str], None] | None = None,
+    ):
         elapsed = time.time() - start_time
         avg = elapsed / current if current else 0
         remaining = total - current
         progress_value = (current / total) * 100 if total else 0
-        progress_ui.set_value(progress_value)
-        label_ui.text = f"Processing {current}/{total} (≈ {int(avg * remaining)}s remaining)"
+        label_text = f"Processing {current}/{total} (≈ {int(avg * remaining)}s remaining)"
+        if progress_ui is not None:
+            progress_ui.set_value(progress_value)
+        if label_ui is not None:
+            label_ui.text = label_text
+        if progress_callback is not None:
+            progress_callback(progress_value, label_text)
 
     # ------------------
     # UPDATE SEGMENT
@@ -738,13 +960,14 @@ class TranslationBackend:
         input_stream,
         file_extension,
         target_language,
-        progress_ui,
-        label_ui,
+        progress_ui=None,
+        label_ui=None,
         processed=False,
         font_size=None,
         autofit=False,
         correlation_id: str | None = None,
         file_metrics: TranslationMetrics | None = None,
+        progress_callback: Callable[[float, str], None] | None = None,
     ):
         self.reset_cancel()
         self.current_target_language = target_language
@@ -766,6 +989,7 @@ class TranslationBackend:
                 do_translate=not processed,
                 correlation_id=correlation_id,
                 file_metrics=metrics,
+                progress_callback=progress_callback,
             )
         elif ext == "pptx":
             result = self.process_pptx(
@@ -778,6 +1002,7 @@ class TranslationBackend:
                 autofit=autofit,
                 correlation_id=correlation_id,
                 file_metrics=metrics,
+                progress_callback=progress_callback,
             )
         elif ext == "pdf":
             result = self.process_pdf(
@@ -788,6 +1013,7 @@ class TranslationBackend:
                 do_translate=not processed,
                 correlation_id=correlation_id,
                 file_metrics=metrics,
+                progress_callback=progress_callback,
             )
         else:
             raise ValueError(f"Unsupported file extension: {file_extension}")

--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -14,7 +14,6 @@ from fastapi import UploadFile, File, Form
 from starlette.responses import Response
 
 from TranslationBackend import TranslationBackend
-from translation_metrics import MetricsCollector
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger("translation.ui")
@@ -45,6 +44,8 @@ class TranslationUI:
         self.current_target_language: str | None = None
         self.current_correlation_id: str | None = None
         self.cancel_button = None
+        self.active_job_id: str | None = None
+        self.job_poll_timer = None
 
         # ── SEGMENT EDITING ─────────────────────────────────────────────
         self.original_segments_map: dict[str, str] = {}
@@ -566,54 +567,18 @@ function startMobileDictation() {
             label_ui
             self.cancel_button
 
-        def translation_task():
-            file_metrics = MetricsCollector()
-            started = time.time()
-            try:
-                out_stream, count, tokens, _, seg_map = self.backend.translate_file(
-                    self.uploaded_file,
-                    self.uploaded_file_extension,
-                    target_language,
-                    progress_ui,
-                    label_ui,
-                    processed=False,
-                    font_size=font_size,
-                    autofit=autofit,
-                    correlation_id=correlation_id,
-                    file_metrics=file_metrics,
-                )
-                if self.backend.cancel_requested:
-                    logging.info("[UI] Translation canceled mid-way.")
-                    _log_event("ui.translation_cancelled", correlation_id=correlation_id)
-                    return
-
-                progress_ui.set_value(100)
-                label_ui.text = "Translation complete."
-
-                # save stats
-                self.current_count = count
-                self.current_cost = tokens * 0.002 / 1000
-
-                # rebuild segment maps
-                self.original_segments_map.clear()
-                self.translated_segments_map.clear()
-                for seg_id, seg_info in seg_map.items():
-                    self.original_segments_map[seg_id] = seg_info["original"]
-                    self.translated_segments_map[seg_id] = seg_info["translated"]
-
-                _log_event(
-                    "ui.translation_complete",
-                    correlation_id=correlation_id,
-                    elapsed_seconds=round(time.time() - started, 3),
-                    metrics=file_metrics.snapshot(),
-                )
-                self.show_result()
-            except Exception as e:
-                logging.error(f"[UI] Translation error: {e}", exc_info=True)
-                _log_event("ui.translation_failed", correlation_id=correlation_id, error=str(e))
-                self.show_error(e)
-
-        Thread(target=translation_task).start()
+        self._start_job_and_poll(
+            progress_ui=progress_ui,
+            label_ui=label_ui,
+            correlation_id=correlation_id,
+            processed=False,
+            font_size=font_size,
+            autofit=autofit,
+            target_language=target_language,
+            complete_event="ui.translation_complete",
+            failed_event="ui.translation_failed",
+            cancelled_event="ui.translation_cancelled",
+        )
 
     def handle_translation_processed(self):
         # display a pre-translated file without re-calling openai
@@ -641,48 +606,111 @@ function startMobileDictation() {
             label_ui
             self.cancel_button
 
-        def processed_task():
-            file_metrics = MetricsCollector()
-            try:
-                out_stream, count, _, _, seg_map = self.backend.translate_file(
-                    self.uploaded_file,
-                    self.uploaded_file_extension,
-                    "",
-                    progress_ui,
-                    label_ui,
-                    processed=True,
-                    correlation_id=correlation_id,
-                    file_metrics=file_metrics,
-                )
-                progress_ui.set_value(100)
-                label_ui.text = "File loaded."
-
-                self.current_count = count
-                self.current_cost = 0.0
-                self.current_target_language = "Processed"
-
-                self.original_segments_map.clear()
-                self.translated_segments_map.clear()
-                for seg_id, seg_info in seg_map.items():
-                    self.original_segments_map[seg_id] = seg_info["original"]
-                    self.translated_segments_map[seg_id] = seg_info["translated"]
-
-                _log_event(
-                    "ui.processed_file_open_complete",
-                    correlation_id=correlation_id,
-                    metrics=file_metrics.snapshot(),
-                )
-                self.show_result()
-            except Exception as e:
-                logging.error(f"[UI] Error loading processed doc: {e}", exc_info=True)
-                _log_event("ui.processed_file_open_failed", correlation_id=correlation_id, error=str(e))
-                self.show_error(e)
-
-        Thread(target=processed_task).start()
+        self._start_job_and_poll(
+            progress_ui=progress_ui,
+            label_ui=label_ui,
+            correlation_id=correlation_id,
+            processed=True,
+            font_size=None,
+            autofit=False,
+            target_language="",
+            complete_event="ui.processed_file_open_complete",
+            failed_event="ui.processed_file_open_failed",
+            cancelled_event="ui.translation_cancelled",
+        )
 
     def cancel_translation(self):
-        self.backend.request_cancel()
+        if self.active_job_id:
+            self.backend.cancel_job(self.active_job_id)
+        else:
+            self.backend.request_cancel()
         self.show_error("Translation was canceled. Please upload or try again.")
+
+    def _start_job_and_poll(
+        self,
+        *,
+        progress_ui,
+        label_ui,
+        correlation_id: str,
+        processed: bool,
+        font_size: int | None,
+        autofit: bool,
+        target_language: str,
+        complete_event: str,
+        failed_event: str,
+        cancelled_event: str,
+    ) -> None:
+        started = time.time()
+        if self.job_poll_timer:
+            self.job_poll_timer.active = False
+            self.job_poll_timer = None
+
+        self.active_job_id = self.backend.start_translation_job(
+            input_stream=self.uploaded_file,
+            file_extension=self.uploaded_file_extension,
+            target_language=target_language,
+            processed=processed,
+            font_size=font_size,
+            autofit=autofit,
+            correlation_id=correlation_id,
+        )
+
+        def poll_job():
+            if not self.active_job_id:
+                return
+            job = self.backend.get_job(self.active_job_id)
+            if not job:
+                return
+            progress_ui.set_value(job.progress)
+            label_ui.text = job.status_message
+
+            if job.state in {"queued", "running"}:
+                return
+
+            if self.job_poll_timer:
+                self.job_poll_timer.active = False
+                self.job_poll_timer = None
+
+            if job.state == "canceled":
+                _log_event(cancelled_event, correlation_id=correlation_id)
+                return
+
+            if job.state == "failed":
+                _log_event(failed_event, correlation_id=correlation_id, error=job.error or "unknown")
+                self.show_error(job.error or "Translation failed")
+                return
+
+            result = self.backend.get_job_result(job.result_handle) if job.result_handle else None
+            if not result:
+                _log_event(failed_event, correlation_id=correlation_id, error="missing_result_handle")
+                self.show_error("Translation failed: missing result payload.")
+                return
+
+            count = result["count"]
+            tokens = result["tokens"]
+            seg_map = result["segment_map"]
+
+            self.current_count = count
+            self.current_cost = 0.0 if processed else tokens * 0.002 / 1000
+            if processed:
+                self.current_target_language = "Processed"
+
+            self.original_segments_map.clear()
+            self.translated_segments_map.clear()
+            for seg_id, seg_info in seg_map.items():
+                self.original_segments_map[seg_id] = seg_info["original"]
+                self.translated_segments_map[seg_id] = seg_info["translated"]
+
+            _log_event(
+                complete_event,
+                correlation_id=correlation_id,
+                elapsed_seconds=round(time.time() - started, 3),
+                metrics=result.get("metrics", {}),
+            )
+            self.show_result()
+            self.active_job_id = None
+
+        self.job_poll_timer = ui.timer(0.2, poll_job)
 
     def get_fresh_download_stream(self):
         # re-generate with edits and return a fresh BytesIO

--- a/tests/test_translation_user_behaviors.py
+++ b/tests/test_translation_user_behaviors.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from io import BytesIO
 from pathlib import Path
 
@@ -47,7 +48,7 @@ def test_cancel_halts_processing_progression(monkeypatch):
 
     calls = {"count": 0}
 
-    def translate_and_cancel(text, target_language):
+    def translate_and_cancel(text, target_language, **_kwargs):
         calls["count"] += 1
         backend.request_cancel()
         return f"translated:{text}"
@@ -126,3 +127,73 @@ def test_translate_fallback_returns_original_on_openai_exception(monkeypatch):
     translated = backend.translate_text(original, target_language="German")
 
     assert translated == "Keep me as-is"
+
+
+def test_translation_job_reaches_succeeded_with_result_handle(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+
+    def fake_translate_file(**kwargs):
+        progress_callback = kwargs.get("progress_callback")
+        if progress_callback:
+            progress_callback(25, "Queued for processing")
+            progress_callback(90, "Almost done")
+        return BytesIO(b"done"), 3, 1200, "translated text", {"seg-1": {"original": "A", "translated": "B"}}
+
+    monkeypatch.setattr(backend, "translate_file", fake_translate_file)
+
+    job_id = backend.start_translation_job(
+        input_stream=BytesIO(b"input"),
+        file_extension="docx",
+        target_language="Spanish",
+        processed=False,
+    )
+
+    deadline = time.time() + 2
+    job = backend.get_job(job_id)
+    while job and job.state in {"queued", "running"} and time.time() < deadline:
+        time.sleep(0.01)
+        job = backend.get_job(job_id)
+
+    assert job is not None
+    assert job.state == "succeeded"
+    assert job.result_handle is not None
+    result = backend.get_job_result(job.result_handle)
+    assert result is not None
+    assert result["count"] == 3
+    assert result["segment_map"]["seg-1"]["translated"] == "B"
+
+
+def test_translation_job_cancel_transitions_to_canceled(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+
+    def slow_translate_file(**kwargs):
+        progress_callback = kwargs.get("progress_callback")
+        for idx in range(1, 20):
+            if backend.cancel_requested:
+                break
+            if progress_callback:
+                progress_callback(idx * 5, f"Step {idx}")
+            time.sleep(0.01)
+        return BytesIO(b"done"), 1, 0, "", {}
+
+    monkeypatch.setattr(backend, "translate_file", slow_translate_file)
+
+    job_id = backend.start_translation_job(
+        input_stream=BytesIO(b"input"),
+        file_extension="docx",
+        target_language="Spanish",
+    )
+    time.sleep(0.03)
+    canceled = backend.cancel_job(job_id)
+    assert canceled is True
+
+    deadline = time.time() + 2
+    job = backend.get_job(job_id)
+    while job and job.state in {"queued", "running"} and time.time() < deadline:
+        time.sleep(0.01)
+        job = backend.get_job(job_id)
+
+    assert job is not None
+    assert job.state == "canceled"


### PR DESCRIPTION
### Motivation
- Decouple long-running file translations from the UI thread so the frontend can start a job and poll/subscribe to status instead of blocking on work.  
- Provide an explicit job lifecycle (queued/running/succeeded/failed/canceled), progress reporting, and a stable `result_handle` for retrieving outputs.  
- Preserve existing cancel semantics and existing output/segment-generation behavior while enabling safer UI integration.

### Description
- Added a `TranslationJob` dataclass and job states plus backend APIs: `start_translation_job`, `get_job`, `get_job_result`, `cancel_job`, and internal `_set_job_state` / `_run_translation_job` helpers to manage lifecycle and results.  
- Refactored backend processing to accept an optional `progress_callback` and made `process_docx`/`process_pptx`/`process_pdf` and `translate_file` tolerant of `progress_ui`/`label_ui` being `None`, with `update_progress` now invoking the callback when present.  
- Implemented job-result storage via a `result_handle` that points to the completed payload (`output_stream`, `segment_map`, metrics, etc.), preserving the previous output generation semantics.  
- Modified the UI to start translation jobs and poll status using `ui.timer` (added `active_job_id`, `job_poll_timer`, and `_start_job_and_poll`), and changed `cancel_translation` to call `cancel_job` when a job is active.  
- Added tests exercising the new job flow and cancellation and adjusted a test to accept extra kwargs for `translate_text` calls (`tests/test_translation_user_behaviors.py`).

### Testing
- Ran `pytest -q tests/test_translation_user_behaviors.py tests/test_mobile_ui_flow.py tests/test_translation_caching_and_retry.py` which executed the new job tests and related suites.  
- Ran the full test suite with `pytest -q` and all tests passed (`19 passed`).  
- New tests include `test_translation_job_reaches_succeeded_with_result_handle` and `test_translation_job_cancel_transitions_to_canceled`, and existing regression tests were left passing after refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92311aec88331a7dac2043f5499b0)