### PR TITLE
Normalize _translate_text_with_context callsites to file_metrics

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -298,14 +298,14 @@ class TranslationBackend:
         text: str,
         target_language: str,
         correlation_id: str | None = None,
-        metrics: TranslationMetrics | None = None,
+        file_metrics: TranslationMetrics | None = None,
     ) -> str:
         try:
             return self.translate_text(
                 text,
                 target_language,
                 correlation_id=correlation_id,
-                file_metrics=metrics,
+                file_metrics=file_metrics,
             )
         except TypeError as error:
             if "unexpected keyword argument" not in str(error):
@@ -612,7 +612,7 @@ class TranslationBackend:
                                 original,
                                 target_language,
                                 correlation_id=correlation_id,
-                                metrics=metrics,
+                                file_metrics=metrics,
                             )
                             if do_translate else original
                         )
@@ -761,7 +761,7 @@ class TranslationBackend:
                         text,
                         target_language,
                         correlation_id=correlation_id,
-                        metrics=file_metrics,
+                        file_metrics=file_metrics,
                     )
                     tf.text = new_text
                     apply_formatting(tf)
@@ -785,7 +785,7 @@ class TranslationBackend:
                 original,
                 target_language,
                 correlation_id=correlation_id,
-                metrics=file_metrics,
+                file_metrics=file_metrics,
             )
             tf.text = new_text
             apply_formatting(tf)
@@ -896,7 +896,7 @@ class TranslationBackend:
                         original,
                         target_language,
                         correlation_id=correlation_id,
-                        metrics=metrics,
+                        file_metrics=metrics,
                     )
                 )
                 self.segment_map[seg_id]["translated"] = new_text

--- a/tests/test_translation_file_metrics_routing.py
+++ b/tests/test_translation_file_metrics_routing.py
@@ -1,0 +1,114 @@
+import sys
+from io import BytesIO
+from pathlib import Path
+
+import fitz
+from docx import Document
+from pptx import Presentation
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from TranslationBackend import TranslationBackend
+from translation_metrics import MetricsCollector
+
+
+def _docx_table_bytes() -> bytes:
+    doc = Document()
+    table = doc.add_table(rows=1, cols=1)
+    table.cell(0, 0).text = "Table source text"
+    output = BytesIO()
+    doc.save(output)
+    output.seek(0)
+    return output.getvalue()
+
+
+def _pptx_bytes() -> bytes:
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    textbox = slide.shapes.add_textbox(left=1_000_000, top=1_000_000, width=4_000_000, height=1_000_000)
+    textbox.text_frame.text = "Slide source text"
+    output = BytesIO()
+    prs.save(output)
+    output.seek(0)
+    return output.getvalue()
+
+
+def _pdf_bytes(text: str) -> bytes:
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    output = BytesIO()
+    doc.save(output)
+    output.seek(0)
+    return output.getvalue()
+
+
+def test_docx_table_translation_uses_file_metrics_kwarg(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+    observed_metrics = []
+
+    def fake_translate_text(text, target_language, correlation_id=None, file_metrics=None):
+        observed_metrics.append(file_metrics)
+        return f"translated:{text}"
+
+    monkeypatch.setattr(backend, "translate_text", fake_translate_text)
+    monkeypatch.setattr(backend, "calculate_tokens", lambda _text: 0)
+
+    custom_metrics = MetricsCollector()
+    backend.process_docx(
+        BytesIO(_docx_table_bytes()),
+        target_language="Spanish",
+        do_translate=True,
+        file_metrics=custom_metrics,
+    )
+
+    assert observed_metrics == [custom_metrics]
+
+
+def test_pptx_shape_translation_uses_file_metrics_kwarg(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+    observed_metrics = []
+
+    def fake_translate_text(text, target_language, correlation_id=None, file_metrics=None):
+        observed_metrics.append(file_metrics)
+        return f"translated:{text}"
+
+    monkeypatch.setattr(backend, "translate_text", fake_translate_text)
+    monkeypatch.setattr(backend, "calculate_tokens", lambda _text: 0)
+
+    custom_metrics = MetricsCollector()
+    backend.process_pptx(
+        BytesIO(_pptx_bytes()),
+        target_language="Spanish",
+        do_translate=True,
+        file_metrics=custom_metrics,
+    )
+
+    assert observed_metrics == [custom_metrics]
+
+
+def test_pdf_block_translation_uses_file_metrics_kwarg(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+    observed_metrics = []
+
+    def fake_translate_text(text, target_language, correlation_id=None, file_metrics=None):
+        observed_metrics.append(file_metrics)
+        return f"translated:{text}"
+
+    monkeypatch.setattr(backend, "translate_text", fake_translate_text)
+    monkeypatch.setattr(backend, "calculate_tokens", lambda _text: 0)
+
+    custom_metrics = MetricsCollector()
+    backend.process_pdf(
+        BytesIO(_pdf_bytes("PDF source text")),
+        target_language="Spanish",
+        do_translate=True,
+        file_metrics=custom_metrics,
+    )
+
+    assert observed_metrics == [custom_metrics]


### PR DESCRIPTION
### Motivation
- Ensure consistent parameter naming for metrics instrumentation across document translation paths to avoid silent mismatches between helpers and the core `translate_text` API.
- Fix lingering `metrics=` usages in DOCX table, PPTX shape, and PDF block translation flows so a per-file `MetricsCollector` instance is always propagated.

### Description
- Renamed the `_translate_segment_text` parameter from `metrics` to `file_metrics` and forwarded it to `translate_text(..., file_metrics=...)` for end-to-end consistency.
- Replaced all `_translate_text_with_context(..., metrics=...)` callsites with `file_metrics=` in DOCX table-cell processing, PPTX table/text-frame branches, and the PDF block translation loop in `TranslationBackend.py`.
- Added `tests/test_translation_file_metrics_routing.py` with targeted tests that assert DOCX table, PPTX shape, and PDF block translation paths receive the same `MetricsCollector` instance via `file_metrics`.

### Testing
- Ran `pytest -q tests/test_translation_file_metrics_routing.py tests/test_translation_user_behaviors.py tests/test_pdf_segment_edit.py` and all tests passed (`11 passed`).
- Performed a targeted code search to confirm no remaining helper callsites pass `metrics=` to `_translate_text_with_context` in `TranslationBackend.py`.
- Existing related tests in `tests/test_translation_user_behaviors.py` and `tests/test_pdf_segment_edit.py` were executed as part of the run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93ca4445083318eb3b22f0b492f93)