### PR TITLE
Unify desktop voice recording controls through voiceUx

### DIFF
--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -1137,27 +1137,29 @@ window.voiceUx = window.voiceUx || (() => {
 <script>
     let recorder = null, stream = null, chunks = [], isRecording = false;
     let selectedMimeType = null;
+    const DESKTOP_SCOPE = 'desktop_voice';
 
     function updateStatus(msg) {
-        let e = document.getElementById('status_label');
-        if (e) e.textContent = msg;
+        window.voiceUx.setStatus(DESKTOP_SCOPE, msg);
     }
     function updateDebug(msg) {
-        let e = document.getElementById('debug_info');
-        if (e) e.textContent = msg;
+        window.voiceUx.setDebug(DESKTOP_SCOPE, msg);
     }
     function updateButtons(recording) {
-        let start = document.getElementById('start_btn'),
-            stop  = document.getElementById('stop_btn');
-        if (start) { start.disabled = recording; start.style.opacity = recording?'0.5':'1'; }
-        if (stop)  { stop.disabled  = !recording; stop.style.opacity = recording?'1':'0.5'; }
+        window.voiceUx.setRecordingButtons(DESKTOP_SCOPE, recording);
         isRecording = recording;
     }
     function setRecordingControlsEnabled(enabled) {
-        let start = document.getElementById('start_btn'),
-            stop  = document.getElementById('stop_btn');
-        if (start) { start.disabled = !enabled; start.style.opacity = enabled ? '1' : '0.5'; }
-        if (stop)  { stop.disabled  = true; stop.style.opacity = '0.5'; }
+        const start = document.getElementById('desktop_voice_start_recording');
+        const stop = document.getElementById('desktop_voice_stop_recording');
+        if (start) {
+            start.disabled = !enabled;
+            start.style.opacity = enabled ? '1' : '0.5';
+        }
+        if (stop) {
+            stop.disabled = true;
+            stop.style.opacity = '0.5';
+        }
         if (!enabled) isRecording = false;
     }
 
@@ -1233,13 +1235,13 @@ window.voiceUx = window.voiceUx || (() => {
 
     async function stopRecording() {
         if(!recorder || recorder.state!=='recording') {
-            window.voiceUx.setDebug('desktop_voice', 'No active recording session.');
+            window.voiceUx.setDebug(DESKTOP_SCOPE, 'No active recording session.');
             return;
         }
-        window.voiceUx.setStatus('desktop_voice', window.voiceUx.states.STOPPING);
-        window.voiceUx.setRecordingButtons('desktop_voice', false);
+        window.voiceUx.setStatus(DESKTOP_SCOPE, window.voiceUx.states.STOPPING);
+        window.voiceUx.setRecordingButtons(DESKTOP_SCOPE, false);
         recorder.onstop = async () => {
-            window.voiceUx.setStatus('desktop_voice', window.voiceUx.states.PROCESSING_AUDIO);
+            window.voiceUx.setStatus(DESKTOP_SCOPE, window.voiceUx.states.PROCESSING_AUDIO);
             const blob = new Blob(chunks, { type: recorder.mimeType });
             let lang = document.getElementById('language_select')?.value || 'es';
             let fd = new FormData();
@@ -1257,11 +1259,11 @@ window.voiceUx = window.voiceUx || (() => {
                     let url = URL.createObjectURL(audio);
                     let player = document.getElementById('out_audio');
                     player.src = url; player.play();
-                    window.voiceUx.setStatus('desktop_voice', window.voiceUx.states.COMPLETE);
+                    window.voiceUx.setStatus(DESKTOP_SCOPE, window.voiceUx.states.COMPLETE);
                 }
             } catch(e) {
-                window.voiceUx.setStatus('desktop_voice', "Error: " + e.message);
-                window.voiceUx.setDebug('desktop_voice', e.message);
+                window.voiceUx.setStatus(DESKTOP_SCOPE, "Error: " + e.message);
+                window.voiceUx.setDebug(DESKTOP_SCOPE, e.message);
             } finally {
                 if(stream) stream.getTracks().forEach(t=>t.stop());
                 recorder = null; chunks = [];

--- a/tests/test_mobile_ui_flow.py
+++ b/tests/test_mobile_ui_flow.py
@@ -129,3 +129,18 @@ def test_mode_switch_syncs_mobile_and_unified_mode():
     assert ui_app.mobile_input_mode == "Image/Camera"
     assert ui_app.input_mode == "Image/Camera"
     assert refresh_calls["count"] == 1
+
+
+def test_desktop_voice_js_uses_desktop_voice_controls_and_voiceux_path():
+    source = Path("TranslationUI.py").read_text()
+
+    assert "document.getElementById('status_label')" not in source
+    assert "document.getElementById('debug_info')" not in source
+    assert "document.getElementById('start_btn')" not in source
+    assert "document.getElementById('stop_btn')" not in source
+    assert "const DESKTOP_SCOPE = 'desktop_voice';" in source
+    assert "window.voiceUx.setStatus(DESKTOP_SCOPE, msg);" in source
+    assert "window.voiceUx.setDebug(DESKTOP_SCOPE, msg);" in source
+    assert "window.voiceUx.setRecordingButtons(DESKTOP_SCOPE, recording);" in source
+    assert "document.getElementById('desktop_voice_start_recording')" in source
+    assert "document.getElementById('desktop_voice_stop_recording')" in source


### PR DESCRIPTION
### Motivation
- The desktop voice JS used mixed DOM selectors and direct `voiceUx` calls which caused inconsistent lifecycle and control updates. 
- The goal is to use the shared `voiceUx` helper API with a single scope for desktop voice UI so status/debug/buttons remain synchronized.

### Description
- Refactored embedded desktop voice JS to introduce `DESKTOP_SCOPE = 'desktop_voice'` and route `updateStatus`, `updateDebug`, and `updateButtons` to `window.voiceUx` using that scope. 
- Replaced legacy/incorrect DOM selectors for enabling controls with the actual rendered IDs by updating `setRecordingControlsEnabled` to use `desktop_voice_start_recording` and `desktop_voice_stop_recording`. 
- Standardized the start/stop lifecycle to consistently use `DESKTOP_SCOPE` for `window.voiceUx` calls during stopping, processing, complete, and error transitions. 
- Added a regression test `test_desktop_voice_js_uses_desktop_voice_controls_and_voiceux_path` in `tests/test_mobile_ui_flow.py` that asserts old selectors are removed and the new `DESKTOP_SCOPE`/`voiceUx` wiring and button IDs are present.

### Testing
- Ran `pytest -q tests/test_mobile_ui_flow.py` and all tests passed (`6 passed in 2.46s`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15df274c83318889310db7077c83)