### PR TITLE
Reset per-run segment state in translate_file and add regression test

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -1062,6 +1062,12 @@ class TranslationBackend:
         progress_callback: Callable[[float, str], None] | None = None,
     ):
         self.reset_cancel(job_id)
+        # Per-run state must not leak across sequential requests.
+        self.segment_map.clear()
+        self.current_document = None
+        self.current_presentation = None
+        self.current_pdf = None
+        self.pdf_overlay_ocg = None
         self.current_target_language = target_language
         metrics = file_metrics or self.metrics
         _log_event(

--- a/tests/test_translation_user_behaviors.py
+++ b/tests/test_translation_user_behaviors.py
@@ -112,6 +112,42 @@ def test_segment_update_modifies_regenerated_output(monkeypatch):
     assert regenerated.paragraphs[0].text == "Contenido actualizado"
 
 
+def test_translate_file_resets_segment_state_between_runs(monkeypatch):
+    """Sequential runs on one backend should not keep prior segment IDs."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    backend = TranslationBackend()
+    monkeypatch.setattr(backend, "translate_text", lambda text, target_language, **_kwargs: f"{target_language}:{text}")
+    monkeypatch.setattr(backend, "calculate_tokens", lambda _text: 0)
+
+    first_stream = BytesIO(_docx_bytes("First run paragraph"))
+    _out1, _count1, _tokens1, _text1, first_map = backend.translate_file(
+        input_stream=first_stream,
+        file_extension="docx",
+        target_language="Spanish",
+        progress_ui=DummyProgress(),
+        label_ui=DummyLabel(),
+        processed=False,
+    )
+
+    first_ids = set(first_map.keys())
+    assert len(first_ids) == 1
+
+    second_stream = BytesIO(_docx_bytes("Second run paragraph", "Second run paragraph 2"))
+    _out2, _count2, _tokens2, _text2, second_map = backend.translate_file(
+        input_stream=second_stream,
+        file_extension="docx",
+        target_language="French",
+        progress_ui=DummyProgress(),
+        label_ui=DummyLabel(),
+        processed=False,
+    )
+
+    second_ids = set(second_map.keys())
+    assert len(second_ids) == 2
+    assert first_ids.isdisjoint(second_ids)
+    assert len(backend.segment_map) == 2
+
+
 def test_translate_fallback_returns_original_on_openai_exception(monkeypatch):
     """If OpenAI fails, user still receives their original text."""
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")


### PR DESCRIPTION
### Motivation

- Prevent stale per-segment and format-specific object state from leaking between sequential `translate_file` calls on the same `TranslationBackend` instance.
- Ensure routing to format-specific processors starts with clean pointers so operations like regeneration or updates refer only to the current run's objects.
- Preserve existing UI clearing behaviour while making correctness independent of UI actions.

### Description

- Clear `self.segment_map` at the start of `translate_file` to remove any segments from prior runs.
- Reset format-specific pointers `current_document`, `current_presentation`, `current_pdf`, and `pdf_overlay_ocg` before routing to `process_docx`/`process_pptx`/`process_pdf`.
- Add `test_translate_file_resets_segment_state_between_runs` to `tests/test_translation_user_behaviors.py` which runs `translate_file` twice on the same backend and asserts the second run has only new segment IDs and that `backend.segment_map` matches the second run.

### Testing

- Ran `pytest -q tests/test_translation_user_behaviors.py`, which completed successfully with `8 passed` (run time ~2.28s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15dd228c8331b964e04752dad9cc)