### PR TITLE
Unify translate_text cache key handling and fix cache metrics accounting

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -349,10 +349,11 @@ class TranslationBackend:
         if not text:
             return text
         metrics = file_metrics or self.metrics
-        cache_key = (target_language, text)
-        if cache_key in self.translation_cache:
-            cached = self.translation_cache[cache_key]
+        cache_key = self._normalize_cache_key(text, target_language, mode="translate")
+        cached = self.translation_cache.get(cache_key)
+        if cached is not None:
             metrics.record_cache_hit()
+            logging.info("[Backend] translate_text cache hit for target=%s", target_language)
             _log_event(
                 "translation.cache_hit",
                 correlation_id=correlation_id,
@@ -361,12 +362,6 @@ class TranslationBackend:
             )
             return cached
         metrics.record_cache_miss()
-
-        cache_key = self._normalize_cache_key(text, target_language, mode="translate")
-        cached = self.translation_cache.get(cache_key)
-        if cached is not None:
-            logging.info("[Backend] translate_text cache hit for target=%s", target_language)
-            return cached
 
         prompt = (
             f"Translate the following text to {target_language}, preserving meaning and context. "

--- a/tests/test_translation_caching_and_retry.py
+++ b/tests/test_translation_caching_and_retry.py
@@ -47,6 +47,32 @@ def test_translate_text_cache_hit_uses_normalized_key(monkeypatch):
     assert stub.calls == 1
 
 
+def test_translate_text_normalization_deduplicates_equivalent_inputs(monkeypatch):
+    backend = _build_backend(monkeypatch)
+    stub = _StubChatCreate(responses=["Bonjour monde"])
+    monkeypatch.setattr(backend.client.chat.completions, "create", stub)
+
+    first = backend.translate_text(" Hello\t world ", " French ")
+    second = backend.translate_text("Hello   world", "french")
+
+    assert first == "Bonjour monde"
+    assert second == "Bonjour monde"
+    assert stub.calls == 1
+
+
+def test_translate_text_cache_metrics_not_double_counted(monkeypatch):
+    backend = _build_backend(monkeypatch)
+    stub = _StubChatCreate(responses=["Ciao mondo"])
+    monkeypatch.setattr(backend.client.chat.completions, "create", stub)
+
+    backend.translate_text("Hello world", "Italian")
+    backend.translate_text("  Hello\tworld  ", " italian ")
+
+    assert backend.metrics.cache_misses == 1
+    assert backend.metrics.cache_hits == 1
+    assert stub.calls == 1
+
+
 def test_instruction_translation_cache_hit_uses_mode_and_instructions(monkeypatch):
     backend = _build_backend(monkeypatch)
     stub = _StubChatCreate(responses=["Veuillez reformuler"])


### PR DESCRIPTION
### Motivation
- Remove an old dual-key caching path to ensure caching is consistent and deduplicates semantically equivalent inputs.
- Ensure cache metrics (`record_cache_hit()` / `record_cache_miss()`) are recorded exactly once per logical lookup so hit/miss counts are accurate.
- Use a single normalized cache key strategy so stored translations and lookups use identical keys.

### Description
- Removed the legacy tuple cache-key branch and now compute one normalized key via `self._normalize_cache_key(text, target_language, mode="translate")` inside `translate_text`.
- Perform a single cache lookup with `self.translation_cache.get(cache_key)` and call `metrics.record_cache_hit()` only on success and `metrics.record_cache_miss()` only on failure.
- Store the translated result back into `self.translation_cache` using the same normalized `cache_key` used for reads.
- Added tests in `tests/test_translation_caching_and_retry.py` to assert that normalization deduplicates equivalent inputs and that cache hit/miss metrics are not double-counted.

### Testing
- Ran `pytest -q tests/test_translation_caching_and_retry.py` and the suite passed with all tests succeeding (`6 passed in 1.74s`).
- The new tests `test_translate_text_normalization_deduplicates_equivalent_inputs` and `test_translate_text_cache_metrics_not_double_counted` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15db4c1c8331812d2188ca265ea9)