### PR TITLE
Add provider abstraction for OpenAI, register translate_text job handler, and improve voice UI headers/fallback

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -5,6 +5,7 @@ import time
 import uuid
 import json
 import random
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from threading import Lock, Thread
 from html import escape
@@ -35,6 +36,52 @@ JOB_STATE_RUNNING = "running"
 JOB_STATE_SUCCEEDED = "succeeded"
 JOB_STATE_FAILED = "failed"
 JOB_STATE_CANCELED = "canceled"
+
+
+class BaseTranslationProvider(ABC):
+    @abstractmethod
+    def create_chat_completion(self, *, messages: list[dict[str, str]], max_tokens: int) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def transcribe_audio(self, *, audio_file: BytesIO) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def synthesize_speech(self, *, text: str) -> bytes:
+        raise NotImplementedError
+
+
+class OpenAITranslationProvider(BaseTranslationProvider):
+    def __init__(self, api_key: str) -> None:
+        self.client = openai.OpenAI(api_key=api_key)
+
+    def create_chat_completion(self, *, messages: list[dict[str, str]], max_tokens: int) -> Any:
+        return self.client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=messages,
+            max_tokens=max_tokens,
+        )
+
+    def transcribe_audio(self, *, audio_file: BytesIO) -> str:
+        transcription = self.client.audio.transcriptions.create(model="whisper-1", file=audio_file)
+        return transcription.text
+
+    def synthesize_speech(self, *, text: str) -> bytes:
+        tts_resp = self.client.audio.speech.create(
+            model="tts-1",
+            voice="nova",
+            input=text,
+            response_format="mp3",
+        )
+        return tts_resp.content if hasattr(tts_resp, "content") else tts_resp
+
+
+def build_translation_provider(provider_name: str, api_key: str) -> BaseTranslationProvider:
+    name = (provider_name or "openai").strip().lower()
+    if name == "openai":
+        return OpenAITranslationProvider(api_key)
+    raise ValueError(f"Unsupported translation provider: {provider_name}")
 
 
 @dataclass
@@ -76,7 +123,10 @@ class TranslationBackend:
         self.api_key = os.getenv("OPENAI_API_KEY")
         if not self.api_key:
             raise ValueError("OPENAI_API_KEY not set.")
-        self.client = openai.OpenAI(api_key=self.api_key)
+        provider_name = os.getenv("TRANSLATION_PROVIDER", "openai")
+        self.provider = build_translation_provider(provider_name, self.api_key)
+        # Backward-compatible attribute used in tests and monkeypatches.
+        self.client = getattr(self.provider, "client", None)
 
         self._manual_cancel_requested = False
         self._active_run_state = TranslationRunState()
@@ -368,7 +418,7 @@ class TranslationBackend:
         attempts = self.max_openai_attempts
         for attempt in range(1, attempts + 1):
             try:
-                return self.client.chat.completions.create(model="gpt-4.1-nano", messages=messages, max_tokens=4000)
+                return self.provider.create_chat_completion(messages=messages, max_tokens=4000)
             except Exception as error:
                 is_transient = self._is_transient_openai_error(error)
                 if attempt >= attempts or not is_transient:
@@ -510,7 +560,7 @@ class TranslationBackend:
             return self.translate_text(text, target_language)
 
     # ──────────────────────── VOICE (WHISPER + TTS) ────────────────────── #
-    def translate_audio(self, audio_bytes: bytes, target_language: str) -> Tuple[str, bytes]:
+    def translate_audio(self, audio_bytes: bytes, target_language: str) -> Tuple[str, str, bytes]:
         """
         1. Transcribe `audio_bytes` with Whisper.  
         2. Translate resulting text.  
@@ -521,18 +571,13 @@ class TranslationBackend:
             audio_file = BytesIO(audio_bytes)
             audio_file.name = "speech.webm"  # Whisper needs a filename
 
-            transcription = self.client.audio.transcriptions.create(model="whisper-1", file=audio_file)
-            source_text: str = transcription.text
+            source_text = self.provider.transcribe_audio(audio_file=audio_file)
             logging.info("[Backend] Whisper transcription: %s", source_text[:60] + "…")
 
             translated_text = self.translate_text(source_text, target_language)
-
-            tts_resp = self.client.audio.speech.create(
-                model="tts-1", voice="nova", input=translated_text, response_format="mp3"
-            )
-            audio_mp3: bytes = tts_resp.content if hasattr(tts_resp, "content") else tts_resp
+            audio_mp3 = self.provider.synthesize_speech(text=translated_text)
             logging.info("[Backend] TTS done (%d bytes)", len(audio_mp3))
-            return translated_text, audio_mp3
+            return source_text, translated_text, audio_mp3
         except Exception as e:
             logging.error("[Backend] translate_audio error: %s", e, exc_info=True)
             raise
@@ -1174,17 +1219,17 @@ class TranslationBackend:
         progress_callback: Callable[[float, str], None] | None = None,
     ):
         self.reset_cancel(job_id)
-        # Per-run state must not leak across sequential requests.
-        self.segment_map.clear()
-        self.current_document = None
-        self.current_presentation = None
-        self.current_pdf = None
-        self.pdf_overlay_ocg = None
-        self.current_target_language = target_language
-        metrics = file_metrics or self.metrics
         state = self._resolve_run_state(job_id=job_id, run_state=run_state)
         if job_id is None and run_state is None:
             state = TranslationRunState()
+        # Per-run state must not leak across sequential requests.
+        state.segment_map.clear()
+        state.current_document = None
+        state.current_presentation = None
+        state.current_pdf = None
+        state.pdf_overlay_ocg = None
+        self.current_target_language = target_language
+        metrics = file_metrics or self.metrics
         _log_event(
             "translation.file_started",
             correlation_id=correlation_id,

--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -8,6 +8,7 @@ import uuid
 from io import BytesIO
 from threading import Thread
 from typing import Any
+from urllib.parse import quote
 
 from nicegui import ui, app
 from fastapi import UploadFile, File, Form
@@ -1251,8 +1252,14 @@ window.voiceUx = window.voiceUx || (() => {
                 const resp = await fetch('/api/voice_translate', { method:'POST', body:fd });
                 if(!resp.ok) throw new Error(await resp.text());
                 const audio = await resp.blob();
-                const orig = resp.headers.get('X-Original-Text') || '';
-                const trans = resp.headers.get('X-Translated-Text') || '';
+                const origHeader = resp.headers.get('X-Original-Text') || '';
+                const transHeader = resp.headers.get('X-Translated-Text') || '';
+                const decodeHeader = (value) => {
+                    if (!value) return '';
+                    try { return decodeURIComponent(value); } catch (_err) { return value; }
+                };
+                const orig = decodeHeader(origHeader);
+                const trans = decodeHeader(transHeader);
                 document.getElementById('original_text').textContent   = orig;
                 document.getElementById('translated_text').textContent= trans;
                 if(audio.size>0){
@@ -1271,6 +1278,34 @@ window.voiceUx = window.voiceUx || (() => {
         };
         recorder.stop();
     }
+
+    async function translateTranscriptFallback() {
+        const lang = document.getElementById('language_select')?.value || 'es';
+        const transcript = document.getElementById('desktop_voice_transcript')?.value || '';
+        const cleaned = transcript.trim();
+        if (!cleaned) {
+            window.voiceUx.setStatus(DESKTOP_SCOPE, 'Please provide transcript text before translating.');
+            return;
+        }
+        window.voiceUx.setStatus(DESKTOP_SCOPE, window.voiceUx.states.TRANSLATING_TEXT);
+        window.voiceUx.setDebug(DESKTOP_SCOPE, `chars=${cleaned.length}`);
+        try {
+            const fd = new FormData();
+            fd.append('text', cleaned);
+            fd.append('language', lang);
+            const resp = await fetch('/api/text_translate', { method: 'POST', body: fd });
+            const data = await resp.json();
+            if (!resp.ok) throw new Error(data?.error || 'Transcript translation failed.');
+            document.getElementById('original_text').textContent = data.original_text || cleaned;
+            document.getElementById('translated_text').textContent = data.translated_text || '';
+            window.voiceUx.setStatus(DESKTOP_SCOPE, window.voiceUx.states.COMPLETE);
+        } catch (e) {
+            window.voiceUx.setStatus(DESKTOP_SCOPE, "Error: " + e.message);
+            window.voiceUx.setDebug(DESKTOP_SCOPE, e.message || 'unknown error');
+        }
+    }
+
+    window.translateTranscriptFallback = translateTranscriptFallback;
 
     window.addEventListener('load', () => {
         const hasGetUserMedia = !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
@@ -1307,31 +1342,19 @@ window.voiceUx = window.voiceUx || (() => {
             data = await file.read()
             if not data:
                 return Response(content=b"", status_code=400, headers={"X-Error":"Empty audio data"})
-            original_text, mp3_bytes = await asyncio.to_thread(
+            original_text, translated_text, mp3_bytes = await asyncio.to_thread(
                 self.backend.translate_audio, data, language
             )
-            # build headers
-            translation_text = {
-                'es':'Translated to Spanish',
-                'fr':'Translated to French',
-                'de':'Translated to German',
-                'zh':'Translated to Chinese'
-            }.get(language, f"Translated to {language.upper()}")
-            safe = original_text[:200] if original_text else "Transcription failed"
-            try:
-                import urllib.parse
-                if len(safe.encode('ascii','ignore')) > len(safe)*0.5:
-                    header_orig = safe
-                else:
-                    header_orig = f"Text in {language}"
-            except:
-                header_orig = f"Text in {language}"
+            safe_original = (original_text or "")[:400]
+            safe_translated = (translated_text or "")[:400]
+            header_orig = quote(safe_original, safe="")
+            header_translated = quote(safe_translated, safe="")
             return Response(
                 content=mp3_bytes,
                 media_type="audio/mpeg",
                 headers={
                     "X-Original-Text": header_orig,
-                    "X-Translated-Text": translation_text,
+                    "X-Translated-Text": header_translated,
                     "X-Target-Language": language,
                     "X-Correlation-Id": correlation_id,
                     "Content-Length": str(len(mp3_bytes))

--- a/job_queue.py
+++ b/job_queue.py
@@ -258,4 +258,35 @@ def build_default_job_executor() -> JobQueueExecutor:
     policy = os.getenv("TRANSLATION_JOB_QUEUE_POLICY", "fifo").strip().lower()
 
     store = JobStore(db_path=db_path)
-    return JobQueueExecutor(handlers={}, store=store, max_workers=max_workers, max_queue_depth=max_depth, queue_policy=policy)
+
+    _backend = {"instance": None}
+
+    def _get_backend():
+        if _backend["instance"] is None:
+            from TranslationBackend import TranslationBackend
+            _backend["instance"] = TranslationBackend()
+        return _backend["instance"]
+
+    def _translate_text_handler(payload: dict[str, Any]) -> dict[str, Any]:
+        text = str(payload.get("text", "")).strip()
+        target_language = str(payload.get("target_language", "")).strip()
+        if not text:
+            raise ValueError("payload.text is required")
+        if not target_language:
+            raise ValueError("payload.target_language is required")
+        translated = _get_backend().translate_text(text, target_language)
+        return {
+            "translated_text": translated,
+            "target_language": target_language,
+        }
+
+    handlers = {
+        "translate_text": _translate_text_handler,
+    }
+    return JobQueueExecutor(
+        handlers=handlers,
+        store=store,
+        max_workers=max_workers,
+        max_queue_depth=max_depth,
+        queue_policy=policy,
+    )

--- a/tests/test_job_queue_and_dashboard.py
+++ b/tests/test_job_queue_and_dashboard.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from job_queue import JobQueueExecutor, JobStore
+from job_queue import JobQueueExecutor, JobStore, build_default_job_executor
 from translation_metrics import DashboardThresholds, MetricsDashboard
 
 
@@ -94,3 +94,11 @@ def test_metrics_dashboard_alerts_for_error_p95_retries_and_queue_depth():
     assert snapshot["max_queue_depth"] >= 3
     alert_types = {alert["type"] for alert in snapshot["alerts"]}
     assert {"error_rate", "p95_duration_seconds", "retry_spike_count", "queue_depth"}.issubset(alert_types)
+
+
+def test_build_default_job_executor_registers_translate_text_handler(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("TRANSLATION_JOB_DB", str(tmp_path / "default_jobs.db"))
+
+    executor = build_default_job_executor()
+
+    assert "translate_text" in executor.handlers

--- a/tests/test_mobile_ui_flow.py
+++ b/tests/test_mobile_ui_flow.py
@@ -144,3 +144,18 @@ def test_desktop_voice_js_uses_desktop_voice_controls_and_voiceux_path():
     assert "window.voiceUx.setRecordingButtons(DESKTOP_SCOPE, recording);" in source
     assert "document.getElementById('desktop_voice_start_recording')" in source
     assert "document.getElementById('desktop_voice_stop_recording')" in source
+
+
+def test_transcript_fallback_js_handler_is_defined_and_exported():
+    source = Path("TranslationUI.py").read_text()
+
+    assert "async function translateTranscriptFallback()" in source
+    assert "window.translateTranscriptFallback = translateTranscriptFallback;" in source
+    assert "fetch('/api/text_translate'" in source
+
+
+def test_voice_ui_decodes_percent_encoded_translation_headers():
+    source = Path("TranslationUI.py").read_text()
+
+    assert "decodeURIComponent(value)" in source
+    assert "const transHeader = resp.headers.get('X-Translated-Text')" in source


### PR DESCRIPTION
### Motivation
- Introduce a pluggable translation provider layer to allow swapping OpenAI or other providers without scattering `openai` calls across the codebase.  
- Ensure the background job executor can expose a simple `translate_text` handler for queued text translations.  
- Improve the voice UI and API so transcript/translation headers are safely transmitted and a client-side fallback is available for manual transcript translation.

### Description
- Add `BaseTranslationProvider` and `OpenAITranslationProvider` and a `build_translation_provider` factory, and switch `TranslationBackend` to use the provider via `self.provider` while keeping `self.client` for backward compatibility.  
- Replace direct `openai` calls inside backend methods with provider methods and update `_create_chat_completion_with_retry` to call `self.provider.create_chat_completion`.  
- Change `translate_audio` signature to return `(source_text, translated_text, mp3_bytes)` and use provider methods for transcription and TTS.  
- Fix per-run state handling in `translate_file` by clearing state on the resolved `run_state` instead of global attributes.  
- Update `TranslationUI.py` to percent-encode large header values server-side with `quote(...)` and decode them client-side with `decodeURIComponent(...)`, and add a client-side `translateTranscriptFallback` function that posts transcript text to `/api/text_translate`.  
- Extend `job_queue.build_default_job_executor` to lazily instantiate a `TranslationBackend` and register a `translate_text` handler so queued jobs can call `translate_text`, and return a `JobQueueExecutor` with that handler.  
- Add tests that assert the default executor registers the handler and that the UI JavaScript contains the new fallback handler and header decoding logic.

### Testing
- Ran the test suite with `pytest`; all tests passed including new tests `test_build_default_job_executor_registers_translate_text_handler`, `test_transcript_fallback_js_handler_is_defined_and_exported`, and `test_voice_ui_decodes_percent_encoded_translation_headers`.  
- Existing job queue and dashboard tests and UI flow tests were executed and succeeded.  
- No automated failures observed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea98cc376083319e55253f9e83d1c2)