### PR TITLE
Add upload-first Image/Camera OCR translation pipeline

### DIFF
--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import base64
 import string
 import time
 import uuid
@@ -581,6 +582,71 @@ class TranslationBackend:
         except Exception as e:
             logging.error("[Backend] translate_audio error: %s", e, exc_info=True)
             raise
+
+    def translate_image_text_blocks(self, image_bytes: bytes, filename: str, target_language: str) -> dict[str, Any]:
+        supported_extensions = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".webp": "image/webp"}
+        extension = os.path.splitext((filename or "").lower())[1]
+        mime_type = supported_extensions.get(extension)
+        if not mime_type:
+            raise ValueError("Unsupported image format. Use PNG, JPG, JPEG, or WEBP.")
+
+        if not image_bytes:
+            raise ValueError("Image payload is empty.")
+
+        image_b64 = base64.b64encode(image_bytes).decode("ascii")
+        prompt = (
+            "Extract all readable text from this image and return JSON with this exact shape: "
+            '{"recognized_blocks":[{"text":"...", "confidence":0.0}]}. '
+            "Confidence must be between 0 and 1."
+        )
+        messages = [
+            {"role": "system", "content": "You are an OCR extraction assistant. Return valid JSON only."},
+            {"role": "user", "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{image_b64}"}},
+            ]},
+        ]
+        completion = self.provider.client.chat.completions.create(
+            model="gpt-4.1-mini",
+            messages=messages,
+            max_tokens=1200,
+        )
+        raw = completion.choices[0].message.content.strip()
+        payload = json.loads(raw)
+        recognized_blocks = payload.get("recognized_blocks", [])
+        if not recognized_blocks:
+            raise ValueError("No text recognized in image.")
+
+        translated_blocks: list[dict[str, Any]] = []
+        confidences: list[float] = []
+        for block in recognized_blocks:
+            source_text = (block.get("text") or "").strip()
+            if not source_text:
+                continue
+            confidence = float(block.get("confidence", 0.0))
+            translated_text = self.translate_text(source_text, target_language)
+            translated_blocks.append({
+                "source_text": source_text,
+                "translated_text": translated_text,
+                "confidence": confidence,
+            })
+            confidences.append(confidence)
+
+        if not translated_blocks:
+            raise ValueError("No valid OCR blocks were returned.")
+        avg_confidence = sum(confidences) / len(confidences)
+        if avg_confidence < 0.45:
+            raise ValueError("Low OCR confidence. Please retake the image in better lighting.")
+
+        return {
+            "recognized_blocks": recognized_blocks,
+            "translated_blocks": translated_blocks,
+            "confidence_metadata": {
+                "average_confidence": round(avg_confidence, 4),
+                "min_confidence": round(min(confidences), 4),
+                "block_count": len(translated_blocks),
+            },
+        }
 
     # ─────────────────────────── TOKEN COUNTS ─────────────────────────── #
     def calculate_tokens(self, total_text: str) -> int:

--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -72,6 +72,11 @@ class TranslationUI:
         self.text_source_input = None
         self.mobile_target_input = None
         self.mobile_voice_input = None
+        self.image_source_upload = None
+        self.image_capture_upload = None
+        self.image_upload_bytes: bytes | None = None
+        self.image_upload_name: str | None = None
+        self.image_translation_result: dict[str, Any] | None = None
         self.current_source_language = "English"
         self.current_target_language = "Spanish"
 
@@ -99,6 +104,11 @@ class TranslationUI:
         app.add_api_route(
             "/api/text_translate",
             self.api_text_translate,
+            methods=["POST"],
+        )
+        app.add_api_route(
+            "/api/image_translate",
+            self.api_image_translate,
             methods=["POST"],
         )
 
@@ -531,7 +541,19 @@ window.voiceUx = window.voiceUx || (() => {
             return
 
         ui.label("Image/Camera input mode selected.").classes("text-sm text-gray-700")
-        ui.label("OCR + camera capture hooks will connect here in the realtime phase.").classes("text-sm text-gray-500")
+        ui.upload(
+            label="Upload image (PNG/JPG/JPEG/WEBP)",
+            multiple=False,
+            on_upload=self.handle_mobile_image_upload,
+        ).classes("w-full")
+        ui.upload(
+            label="Camera capture fallback",
+            multiple=False,
+            auto_upload=True,
+            on_upload=self.handle_mobile_image_upload,
+        ).props("accept=image/* capture=environment").classes("w-full")
+        if self.image_upload_name:
+            ui.label(f"Selected image: {self.image_upload_name}").classes("text-sm text-gray-600")
 
     def mobile_page(self):
         self.mobile_mode = True
@@ -575,13 +597,21 @@ window.voiceUx = window.voiceUx || (() => {
             return
 
         if self.input_mode == "Image/Camera":
+            if not self.image_upload_bytes or not self.image_upload_name:
+                self.show_error("Please upload or capture an image before translating.")
+                return
             self.progress_container.clear()
             self.result_container.clear()
-            self._show_banner(
-                self.result_container,
-                "Image/Camera mode is wired to the shared workspace. OCR/realtime processing will be added next.",
-                "warning",
-            )
+            self.stats_container.clear()
+            try:
+                self.image_translation_result = self.backend.translate_image_text_blocks(
+                    self.image_upload_bytes,
+                    self.image_upload_name,
+                    language,
+                )
+                self.show_mobile_image_result(language)
+            except Exception as ex:
+                self.show_error(str(ex))
             return
 
         source_text = (self.text_source_input.value or "").strip() if self.text_source_input else ""
@@ -617,6 +647,33 @@ window.voiceUx = window.voiceUx || (() => {
         except Exception as ex:
             logging.error("[UI] Mobile voice translation error: %s", ex, exc_info=True)
             self.show_error(ex)
+
+    def handle_mobile_image_upload(self, event):
+        self.image_upload_name = event.name
+        self.image_upload_bytes = event.content.read()
+        ui.notify(f"Selected image '{self.image_upload_name}'", type="positive")
+        self.refresh_upload_ui()
+
+    def show_mobile_image_result(self, language: str) -> None:
+        self.result_container.clear()
+        result = self.image_translation_result or {}
+        blocks = result.get("translated_blocks", [])
+        confidence = result.get("confidence_metadata", {})
+        with self.result_container:
+            with ui.card().classes("w-full p-4 space-y-3"):
+                ui.label(f"Image OCR translation → {language}").classes("text-lg font-semibold")
+                ui.label(
+                    f"Confidence avg: {confidence.get('average_confidence', 0)} "
+                    f"across {confidence.get('block_count', 0)} blocks"
+                ).classes("text-xs text-gray-600")
+                for idx, block in enumerate(blocks, start=1):
+                    with ui.grid(columns=2).classes("w-full gap-2 border rounded p-2"):
+                        with ui.column().classes("w-full"):
+                            ui.label(f"Extracted #{idx}").classes("text-xs font-semibold text-gray-600")
+                            ui.label(block.get("source_text", "")).classes("text-sm bg-gray-50 border rounded p-2")
+                        with ui.column().classes("w-full"):
+                            ui.label(f"Translated #{idx}").classes("text-xs font-semibold text-gray-600")
+                            ui.label(block.get("translated_text", "")).classes("text-sm bg-blue-50 border rounded p-2")
 
     def show_mobile_voice_result(self, original_text, translated_text, language):
         self.result_container.clear()
@@ -1411,6 +1468,34 @@ window.voiceUx = window.voiceUx || (() => {
             _log_event("ui.text_translate_failed", correlation_id=correlation_id, error=str(e))
             return JSONResponse(
                 {"error": f"Transcript translation failed: {e}"},
+                status_code=500,
+                headers={"X-Correlation-Id": correlation_id},
+            )
+
+    async def api_image_translate(
+        self,
+        file: UploadFile = File(...),
+        language: str = Form(...),
+    ) -> JSONResponse:
+        correlation_id = str(uuid.uuid4())
+        try:
+            payload = await file.read()
+            result = await asyncio.to_thread(
+                self.backend.translate_image_text_blocks,
+                payload,
+                file.filename or "uploaded_image",
+                language or "es",
+            )
+            return JSONResponse(result, headers={"X-Correlation-Id": correlation_id})
+        except ValueError as err:
+            return JSONResponse(
+                {"error": str(err)},
+                status_code=400,
+                headers={"X-Correlation-Id": correlation_id},
+            )
+        except Exception as err:
+            return JSONResponse(
+                {"error": f"Image translation failed: {err}"},
                 status_code=500,
                 headers={"X-Correlation-Id": correlation_id},
             )

--- a/tests/test_image_translation_pipeline.py
+++ b/tests/test_image_translation_pipeline.py
@@ -1,0 +1,101 @@
+import json
+from io import BytesIO
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from TranslationUI import TranslationUI
+
+
+class _Msg:
+    def __init__(self, content):
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, content):
+        self.message = _Msg(content)
+
+
+class _Resp:
+    def __init__(self, content):
+        self.choices = [_Choice(content)]
+
+
+class _Completions:
+    def __init__(self, content):
+        self._content = content
+
+    def create(self, **_kwargs):
+        return _Resp(self._content)
+
+
+class _Chat:
+    def __init__(self, content):
+        self.completions = _Completions(content)
+
+
+class _Client:
+    def __init__(self, content):
+        self.chat = _Chat(content)
+
+
+class _Provider:
+    def __init__(self, content):
+        self.client = _Client(content)
+
+
+class _Upload:
+    def __init__(self, payload: bytes, name: str):
+        self._payload = payload
+        self.filename = name
+
+    async def read(self):
+        return self._payload
+
+
+def test_backend_image_ocr_translation_success(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    ui_app = TranslationUI()
+    backend = ui_app.backend
+    backend.provider = _Provider(json.dumps({"recognized_blocks": [{"text": "hello", "confidence": 0.91}]}))
+    monkeypatch.setattr(backend, "translate_text", lambda text, lang: f"{lang}:{text}")
+
+    result = backend.translate_image_text_blocks(b"abc", "sample.png", "Spanish")
+
+    assert result["translated_blocks"][0]["translated_text"] == "Spanish:hello"
+    assert result["confidence_metadata"]["block_count"] == 1
+
+
+def test_backend_image_ocr_unsupported_format_error():
+    import os
+    os.environ["OPENAI_API_KEY"] = "test-key"
+    ui_app = TranslationUI()
+    backend = ui_app.backend
+
+    try:
+        backend.translate_image_text_blocks(b"abc", "sample.gif", "Spanish")
+    except ValueError as err:
+        assert "Unsupported image format" in str(err)
+    else:
+        raise AssertionError("Expected ValueError for unsupported format")
+
+
+async def _call_api_image_translate(ui_app):
+    upload = _Upload(b"abc", "sample.gif")
+    return await ui_app.api_image_translate(upload, "Spanish")
+
+
+def test_api_image_translate_error_path_for_unsupported_format():
+    import asyncio
+    import os
+    os.environ["OPENAI_API_KEY"] = "test-key"
+
+    ui_app = TranslationUI()
+    response = asyncio.run(_call_api_image_translate(ui_app))
+
+    assert response.status_code == 400
+    assert b"Unsupported image format" in response.body


### PR DESCRIPTION
### Motivation
- Provide an upload-first Image/Camera workflow in the unified translation workspace so users can upload or capture photos for OCR-based translation. 
- Replace the previous placeholder for Image/Camera mode with a real backend OCR+translation path and result rendering. 
- Surface clear errors for unsupported image formats and low OCR confidence so the UX is actionable.

### Description
- Added image upload and camera-capture fallback to the source panel by updating `_render_source_input_panel` to include two `ui.upload` entry points and state fields for `image_upload_bytes`, `image_upload_name`, and `image_translation_result` in `TranslationUI.py`. 
- Wired the image path into the unified translation action by extending `start_mobile_translation` to validate the uploaded image, call the backend image OCR/translate pipeline, and render results via `show_mobile_image_result`, plus a `handle_mobile_image_upload` helper. 
- Added a new API route `POST /api/image_translate` and handler `api_image_translate` in `TranslationUI.py` that forwards image bytes to the backend and returns structured OCR+translation JSON, with `400` for validation errors and `500` for unexpected failures. 
- Implemented `TranslationBackend.translate_image_text_blocks` which accepts image bytes and filename, validates formats (PNG/JPG/JPEG/WEBP), invokes the multimodal chat/completion path to extract `recognized_blocks` JSON, translates each block via `translate_text`, computes confidence metadata, and raises clear `ValueError`s for unsupported formats, empty payloads, missing OCR blocks, or low average confidence. 

### Testing
- Added `tests/test_image_translation_pipeline.py` which covers a successful OCR+translation path and error paths for unsupported image formats at both backend and API layers. 
- Ran the core test command `pytest -q tests/test_image_translation_pipeline.py tests/test_mobile_ui_flow.py`. 
- All automated tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f29d60c5c8331ad346e38ce989296)