### PR TITLE
Raise on translation failure; add PASSAGE_PLAN.md plan of record

### DIFF
--- a/PASSAGE_PLAN.md
+++ b/PASSAGE_PLAN.md
@@ -1,0 +1,147 @@
+# Passage — plan of record
+
+**This file is the single source of truth for the LanguageTranslation → Passage rebuild.**
+Any session (human or agent) resuming this work starts here: read "Current state", pick up the
+first unchecked item, and update this file as work lands. Keep it committed to git.
+
+Last updated: 2026-07-05.
+
+## What Passage is
+
+`LanguageTranslation` (NiceGUI app, Cloud Run service `translation-app`, GCP project
+`translation-app-452812`) rebuilt as **Passage**: a reliable, well-designed translation
+workspace with accounts, model optionality (local 5090 / BYO endpoint / cheap hosted), and a
+flagship feature — layout-preserving PDF translation with segment-level traces of every
+machine translation and human edit.
+
+## Locked decisions (2026-07-05, with David)
+
+- **Name: Passage.** Keep NiceGUI and polish it — no React rewrite now. Keep `/api/*` clean so a swap stays possible.
+- **Auth/DB: share the finplatform Supabase project** — one login, one future bundled subscription.
+  Port finplatform's `jwt_verify` + credits patterns. NOTE: finplatform tokens are now
+  **ES256/JWKS** (HS256 is legacy) — port that version.
+- **Design: editorial / paper-and-ink identity**, deliberately distinct from finplatform.
+  David picks from 2–3 static HTML mockups before any real UI is built.
+- **Models: provider-agnostic** via OpenAI-compatible `base_url` + `key` + `model` profiles.
+  Local default = TranslateGemma via Ollama on David's 5090 — he wants to try **4b and smaller,
+  not just 12b**; 27b only as a quality toggle. TranslateGemma has ~2K-token input context →
+  segment chunking must cap segment size. Hosted tier stays `gpt-4.1-nano` for now.
+- **Flagship: PDF-first** — a finplatform print-to-PDF report dropped into Passage → layout-preserved
+  translated PDF via pdf2zh/BabelDOC as an async job. Live HTML/article translation deferred, seams kept ready.
+- **Traces: Langfuse-shaped JSONL/tables** (trace = document run, generation = segment,
+  score/event = human edit). No self-hosted Langfuse.
+
+## Repo facts a fresh session needs
+
+- Entry: `TranslationUI.py` → `ui.run(host="0.0.0.0", port=PORT)`. Backend: `TranslationBackend.py`
+  with a provider seam (`build_translation_provider`) and a real segment model
+  (`segment_map`, `_translate_segment_text`, `update_segment`).
+- **pytest IS correct in this repo** (finplatform's no-pytest rule does not apply):
+  `.venv\Scripts\python.exe -m pytest tests/` — uv venv, Python 3.12.
+- `job_queue.py` and `translation_metrics.py` are dead code — wire in for the PDF job phase or delete.
+- CI: `.github/workflows/deploy.yml` — tests gate the deploy; the deploy step reads
+  `OPENAI_API_KEY` from a GitHub Actions secret.
+
+## Current state
+
+- **Phase 0 shipped** (commit `47d2851`, branch `fix/boot-crash-and-ci-gate`, PR #34):
+  boot crash fixed (malformed `add_api_route` from the PR #33 merge, split into two calls;
+  undefined `text_status_scope` defined), PORT env honored, backend boots without
+  `OPENAI_API_KEY` (`_require_provider` guard), deploy.yml gates on pytest (44 tests).
+- **Honest-error contract shipped** (this branch): `translate_text` now **raises** on provider
+  failure instead of echoing the source text back disguised as a translation. All callers
+  verified: UI call sites catch and surface via `show_error`/`ui.notify`; document jobs land in
+  a failed state. Tests updated (`test_translate_text_raises_after_max_attempts`,
+  `test_translate_raises_on_openai_exception`). Plus two mobile fixes: NiceGUI
+  `on_value_change` for the mode selector, progress widgets created inside their container.
+- **Suite green**: 44/44 passing locally.
+
+### Blocked on David (do these once, in the browser)
+
+- [ ] Add repo secret: GitHub → Settings → Secrets and variables → Actions → `OPENAI_API_KEY`
+      (deploy fails healthy-boot without it).
+- [ ] Merge PR #34 (`fix/boot-crash-and-ci-gate`) once CI is green, confirm the Cloud Run
+      revision goes healthy.
+
+## Roadmap
+
+### Phase 0 — Unbreak prod — DONE (pending PR merge + secret above)
+
+### Phase 1 — Brand + design prototypes (next up)
+
+1. [ ] 2–3 static HTML mockups (Artifact) of the main workspace in editorial directions —
+       e.g. (a) warm paper/ink + burgundy + serif display, (b) gallery-white + deep green,
+       (c) cream + midnight-blue. Each shows: header with Passage wordmark, language bar,
+       source/target panels, segment list, error + loading states.
+2. [ ] David picks → extract winner into design tokens: `static/passage.css` (CSS variables)
+       + `theme.py` (token constants for NiceGUI classes). Kill ad-hoc Tailwind color strings.
+3. [ ] Brand assets: favicon, page title, `ui.run(favicon=...)`, OG meta, replace `Multilingual.png`.
+
+### Phase 2 — UI/UX rehaul (NiceGUI, on the chosen tokens)
+
+1. [ ] Restructure `TranslationUI.py` (~1,700 lines) into `passage/ui/` package
+       (`pages.py`, `workspace.py`, `segments.py`, `theme.py`, `errors.py`).
+2. [ ] One design system: buttons/banners from theme constants, real icons via `ui.icon`.
+3. [ ] Unified error + loading model: single `notify_error()` path, friendly message +
+       expandable detail, retry affordance, buttons disabled in flight, shared skeleton/progress.
+4. [ ] Merge the two segment editors into ONE segment review surface (inline Advanced editor
+       absorbs the Document Editor dialog) — this surface later doubles as the trace viewer.
+5. [ ] Responsive layout instead of the `/mobile` UA-redirect; retire `/mobile`.
+6. [ ] Restyle `/voice` onto the same system.
+7. [ ] Remove dead UI (legacy PPTX `handle_upload`) and dead modules (`job_queue.py` /
+       `translation_metrics.py`) or wire them in deliberately — default remove.
+
+### Phase 3 — Model optionality
+
+1. [ ] Generalize provider to `ChatCompletionsProvider` (`base_url`+`api_key`+`model`;
+       the `openai` SDK supports this natively). Nothing outside the provider references OpenAI by name.
+2. [ ] Provider profiles + settings UI: named profiles stored per-user (Supabase jsonb; local
+       JSON signed-out). "Test connection" = `GET /v1/models` (soft) + 1-token completion (hard).
+       Model field = free-text + dropdown from `/v1/models`. Generous timeouts (local cold start
+       30–120s), non-streaming fallback.
+3. [ ] Local default: TranslateGemma via Ollama (`http://host:11434/v1`) — model tag freely
+       selectable (4b/smaller experiments; 27b toggle). **Cap segment size for ~2K-token context.**
+4. [ ] Hosted tier: keep `gpt-4.1-nano`, credit-gate via finplatform metering pattern later.
+5. [ ] Consolidate the model zoo (nano vs mini vs tiktoken's gpt-4o-mini) into one config surface.
+
+### Phase 4 — Accounts + workspace (shared finplatform Supabase)
+
+1. [ ] Port `finplatform/auth/jwt_verify.py` (**the ES256/JWKS version**) into `passage/auth/`.
+       Degrade to anon/no-op without keys (zero-config local dev).
+2. [ ] Sign-in UI: magic-link + Google via GoTrue REST (mirror finplatform's SDK-less flow).
+       Header account chip; signed-out users keep full local use.
+3. [ ] Per-user workspace: `passage_documents`, `passage_segments` tables + `passage-files`
+       Storage bucket, RLS by uid. "Recent Documents" reads user rows, not the server
+       filesystem — also fixes the global-state collision (scope run state per session/user).
+4. [ ] Metering: adapt the `_meter`/402 pattern; no-op unless keys set. Billing unification
+       with finplatform is later — schema just must not preclude it.
+
+### Phase 5 — Format-preserving PDF translation + traces (the flagship)
+
+1. [ ] Integrate **pdf2zh / BabelDOC** as an async job (wire in or replace `job_queue.py`).
+       Output mono + bilingual variants. DOCX stays on python-docx (+ run-merge for bold/italic).
+2. [ ] HTML/article pipeline NOT built now — keep seams: segments format-agnostic, translation
+       exposed as a clean JSON endpoint.
+3. [ ] finplatform bridge v1 = the PDF itself: make Passage excellent on finplatform
+       print-to-PDF exports; test with real exports.
+4. [ ] Traces: JSONL + `passage_traces` (Langfuse data model). Write points = existing
+       `record_feedback` + segment editor callbacks. Trace viewer = a tab on the segment
+       review surface: per-segment timeline, edit-distance vs machine output, cost per document.
+
+## Sequencing & scope
+
+Order: 0 → 1 → 2 → 3 → 4 → 5. Phases 1–2 are the visible rehaul. 3 before 4 (BYO endpoint has
+value signed-out); 4 before 5's storage-backed parts.
+
+**Out of scope now**: React rewrite, self-hosted Langfuse, collaborative editing,
+billing unification, TranslateGemma on hosted GPUs.
+
+## Verification (every phase)
+
+- `.venv\Scripts\python.exe -m pytest tests/` green; extend tests alongside changes.
+- Boot: `docker build` + `docker run -e PORT=8080` → `/` and `/api/text_translate` respond.
+- Deploy: branch push → CI green → merge → Cloud Run revision healthy
+  (`gcloud run services describe translation-app`).
+- UX: screenshot pass (desktop + narrow) vs the chosen mockup.
+- Flagship: real finplatform print-to-PDF export → Passage → side-by-side layout compare;
+  every segment has a trace row; a human edit produces a score/event.

--- a/TranslationBackend.py
+++ b/TranslationBackend.py
@@ -517,8 +517,9 @@ class TranslationBackend:
             logging.info("[Backend] Translated len=%d → len=%d", len(text), len(result))
             return result
         except Exception as e:
+            # Never echo the source back as a "translation" — surface the failure.
             logging.error("[Backend] translate_text error: %s", e, exc_info=True)
-            return text
+            raise
 
     def translate_text_with_instructions(
         self, original_text: str, target_language: str, instructions: str

--- a/TranslationUI.py
+++ b/TranslationUI.py
@@ -595,7 +595,7 @@ window.voiceUx = window.voiceUx || (() => {
                         {"Text": "Text", "Document": "Document", "Image/Camera": "Image/Camera"},
                         value=self.input_mode,
                     ).classes("h-10 min-h-0 px-2 rounded-md")
-                    mode_selector.on("update:model-value", lambda e: self.set_mobile_input_mode(e.args))
+                    mode_selector.on_value_change(lambda e: self.set_mobile_input_mode(e.value))
                     translate_button = ui.button("Translate", on_click=self.start_mobile_translation).classes(self.button_primary_classes)
                     translate_button.props(f"id={self.text_status_scope}_manual_translate")
 
@@ -719,11 +719,9 @@ window.voiceUx = window.voiceUx || (() => {
         self.result_container.clear()
         self.stats_container.clear()
 
-        progress_ui = ui.circular_progress(value=0, max=100, show_value=True).classes("mt-3")
-        label_ui = ui.label("Translating text...").classes("text-sm text-gray-700")
         with self.progress_container:
-            progress_ui
-            label_ui
+            progress_ui = ui.circular_progress(value=0, max=100, show_value=True).classes("mt-3")
+            label_ui = ui.label("Translating text...").classes("text-sm text-gray-700")
 
         def voice_task():
             self._run_mobile_voice_translation(source_text, language, progress_ui, label_ui)

--- a/tests/test_translation_caching_and_retry.py
+++ b/tests/test_translation_caching_and_retry.py
@@ -111,7 +111,9 @@ def test_translate_text_retries_on_transient_openai_error(monkeypatch):
     assert slept[0] >= backend.retry_base_delay
 
 
-def test_translate_text_stops_after_max_attempts(monkeypatch):
+def test_translate_text_raises_after_max_attempts(monkeypatch):
+    # A failed translation must surface as an error, never echo the source
+    # text back as if it were translated.
     backend = _build_backend(monkeypatch)
     backend.max_openai_attempts = 3
     backend.retry_base_delay = 0
@@ -123,8 +125,7 @@ def test_translate_text_stops_after_max_attempts(monkeypatch):
     monkeypatch.setattr(backend.client.chat.completions, "create", stub)
     monkeypatch.setattr("TranslationBackend.time.sleep", lambda _seconds: None)
 
-    original = "Fallback text"
-    translated = backend.translate_text(original, "Italian")
+    with pytest.raises(Exception, match="still failing"):
+        backend.translate_text("Fallback text", "Italian")
 
-    assert translated == original
     assert stub.calls == backend.max_openai_attempts

--- a/tests/test_translation_user_behaviors.py
+++ b/tests/test_translation_user_behaviors.py
@@ -148,8 +148,9 @@ def test_translate_file_resets_segment_state_between_runs(monkeypatch):
     assert len(backend.segment_map) == 2
 
 
-def test_translate_fallback_returns_original_on_openai_exception(monkeypatch):
-    """If OpenAI fails, user still receives their original text."""
+def test_translate_raises_on_openai_exception(monkeypatch):
+    """If the provider fails, the error surfaces — the source text must never
+    be echoed back to the user disguised as a translation."""
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     backend = TranslationBackend()
@@ -159,10 +160,8 @@ def test_translate_fallback_returns_original_on_openai_exception(monkeypatch):
 
     monkeypatch.setattr(backend.client.chat.completions, "create", raise_openai_error)
 
-    original = "\tKeep me as-is\t"
-    translated = backend.translate_text(original, target_language="German")
-
-    assert translated == "Keep me as-is"
+    with pytest.raises(RuntimeError, match="simulated OpenAI outage"):
+        backend.translate_text("\tKeep me as-is\t", target_language="German")
 
 
 def test_translation_job_reaches_succeeded_with_result_handle(monkeypatch):


### PR DESCRIPTION
## What

- `translate_text` now **raises** on provider failure instead of echoing the source text back disguised as a translation. UI call sites surface the error (`show_error` / `ui.notify`); document jobs land in a failed state. Tests updated to assert the honest contract.
- Two mobile fixes: mode selector uses `on_value_change`, progress widgets are created inside their container.
- Adds **PASSAGE_PLAN.md** — the durable single source of truth for the Passage rebuild (locked decisions, current state, phase roadmap, verification), so any fresh session resumes without archaeology.
